### PR TITLE
Resnet18: conv4_x and conv5_x downsample

### DIFF
--- a/run_regression.py
+++ b/run_regression.py
@@ -743,37 +743,25 @@ def add_layers(network, layers, layer_counts, uniquify):
 
 
 def append_glb_base_addresses(kwargs, mu_glb_base_address):
-
-    # FIXME: Temporary HACK
-    zircon_cgra_psum_workaround = "ZIRCON_CGRA_PSUM_WORKAROUND" in os.environ and os.environ["ZIRCON_CGRA_PSUM_WORKAROUND"] == "1"
-    num_psums = "NUM_PSUMS" in os.environ and int(os.environ["NUM_PSUMS"]) if zircon_cgra_psum_workaround else 1
-    kernel_and_stride_hack = "KERNEL_AND_STRIDE_HACK" in os.environ and os.environ["KERNEL_AND_STRIDE_HACK"] == "1"
+    zircon_fx_fy_stride_workaround = "ZIRCON_FX_FY_STRIDE_WORKAROUND" in os.environ and os.environ["ZIRCON_FX_FY_STRIDE_WORKAROUND"] == "1"
 
     # Append GLB base addresses to the kwargs for input, weight, bias, inputScale, and weightScale tensors
     input_base_address = mu_glb_base_address
 
     # multiply all element in kwargs['input']['tensor']['shape'] together and add to input_base_address
     input_num_elements = functools.reduce(operator.mul, kwargs['input']['tensor']['shape'], 1)
-    if zircon_cgra_psum_workaround:
-        input_num_elements /= num_psums
     inputScale_base_address = input_base_address + math.ceil(input_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
 
     inputScale_num_elements = functools.reduce(operator.mul, kwargs['input_scale']['tensor']['shape'], 1)
-    if zircon_cgra_psum_workaround:
-        inputScale_num_elements /= num_psums
     weight_base_address = inputScale_base_address + math.ceil(inputScale_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
 
     weight_num_elements = functools.reduce(operator.mul, kwargs['weight']['tensor']['shape'], 1)
-    if zircon_cgra_psum_workaround:
-        weight_num_elements /= num_psums
-    if kernel_and_stride_hack:
+    if zircon_fx_fy_stride_workaround:
         weight_num_elements *= 3 * 3
     weightScale_base_address = weight_base_address + math.ceil(weight_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
 
     weightScale_num_elements = functools.reduce(operator.mul, kwargs['weight_scale']['tensor']['shape'], 1)
-    if zircon_cgra_psum_workaround:
-        weightScale_num_elements /= num_psums
-    if kernel_and_stride_hack:
+    if zircon_fx_fy_stride_workaround:
         weightScale_num_elements *= 3 * 3
 
     bias_base_address = weightScale_base_address + math.ceil(weightScale_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space

--- a/run_regression.py
+++ b/run_regression.py
@@ -745,7 +745,8 @@ def add_layers(network, layers, layer_counts, uniquify):
 def append_glb_base_addresses(kwargs, mu_glb_base_address):
 
     # FIXME: Temporary HACK
-    reduction_kernel_hack = True
+    reduction_kernel_hack = False
+    kernel_and_stride_hack = "KERNEL_AND_STRIDE_HACK" in os.environ and os.environ["KERNEL_AND_STRIDE_HACK"] == "1"
 
     # Append GLB base addresses to the kwargs for input, weight, bias, inputScale, and weightScale tensors
     input_base_address = mu_glb_base_address
@@ -764,11 +765,16 @@ def append_glb_base_addresses(kwargs, mu_glb_base_address):
     weight_num_elements = functools.reduce(operator.mul, kwargs['weight']['tensor']['shape'], 1)
     if reduction_kernel_hack:
         weight_num_elements /= 2
+    if kernel_and_stride_hack:
+        weight_num_elements *= 3 * 3
     weightScale_base_address = weight_base_address + math.ceil(weight_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
 
     weightScale_num_elements = functools.reduce(operator.mul, kwargs['weight_scale']['tensor']['shape'], 1)
     if reduction_kernel_hack:
         weightScale_num_elements /= 2
+    if kernel_and_stride_hack:
+        weightScale_num_elements *= 3 * 3
+
     bias_base_address = weightScale_base_address + math.ceil(weightScale_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
 
     kwargs['input']['tensor']['glb_base_address'] = input_base_address

--- a/run_regression.py
+++ b/run_regression.py
@@ -9,6 +9,10 @@ import re
 import signal
 import sys
 from deepdiff import DeepDiff
+import math
+
+import functools
+import operator
 
 from google.protobuf import text_format
 from google.protobuf.json_format import MessageToDict
@@ -738,6 +742,42 @@ def add_layers(network, layers, layer_counts, uniquify):
                 layer_counts[network][name] = 1
 
 
+def append_glb_base_addresses(kwargs, mu_glb_base_address):
+
+    # FIXME: Temporary HACK
+    reduction_kernel_hack = True
+
+    # Append GLB base addresses to the kwargs for input, weight, bias, inputScale, and weightScale tensors
+    input_base_address = mu_glb_base_address
+
+    # multiply all element in kwargs['input']['tensor']['shape'] together and add to input_base_address
+    input_num_elements = functools.reduce(operator.mul, kwargs['input']['tensor']['shape'], 1)
+    if reduction_kernel_hack:
+        input_num_elements /= 2
+    inputScale_base_address = input_base_address + math.ceil(input_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
+
+    inputScale_num_elements = functools.reduce(operator.mul, kwargs['input_scale']['tensor']['shape'], 1)
+    if reduction_kernel_hack:
+        inputScale_num_elements /= 2
+    weight_base_address = inputScale_base_address + math.ceil(inputScale_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
+
+    weight_num_elements = functools.reduce(operator.mul, kwargs['weight']['tensor']['shape'], 1)
+    if reduction_kernel_hack:
+        weight_num_elements /= 2
+    weightScale_base_address = weight_base_address + math.ceil(weight_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
+
+    weightScale_num_elements = functools.reduce(operator.mul, kwargs['weight_scale']['tensor']['shape'], 1)
+    if reduction_kernel_hack:
+        weightScale_num_elements /= 2
+    bias_base_address = weightScale_base_address + math.ceil(weightScale_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
+
+    kwargs['input']['tensor']['glb_base_address'] = input_base_address
+    kwargs['input_scale']['tensor']['glb_base_address'] = inputScale_base_address
+    kwargs['weight']['tensor']['glb_base_address'] = weight_base_address
+    kwargs['weight_scale']['tensor']['glb_base_address'] = weightScale_base_address
+    kwargs['bias']['tensor']['glb_base_address'] = bias_base_address
+
+
 def create_tensor_metadata_json(layer, params_dict):
     # create tensor_metadata.json file, needed by aha flow
     tensor_metadata = {
@@ -762,12 +802,15 @@ def create_tensor_metadata_json(layer, params_dict):
             op_dict = {}
             op_dict["name"] = op["op"]["name"]
             op_dict["kwargs"] = op["op"]["kwargs"]
+            # Should be if "conv2d" or if "matmul", etc. Generalize this in the future
+            if "conv2d" in op_dict["name"]:
+                append_glb_base_addresses(op_dict["kwargs"], mu_glb_base_address)
             for arg_key in op_dict["kwargs"]:
-                arg = op_dict["kwargs"][arg_key]
-                tensor = arg.get("tensor")
-                # Remove memory field from voyager compiler (mapping to GLB memory is different and handled in the aha flow)
-                if isinstance(tensor, dict):
-                    tensor.pop("memory", None)
+                    arg = op_dict["kwargs"][arg_key]
+                    tensor = arg.get("tensor")
+                    if isinstance(tensor, dict):
+                        if "memory" in tensor:
+                            del tensor["memory"]  # Remove memory field from voyager compiler (mapping to GLB memory is different and handled in the aha flow)
             tensor_metadata["ops"].append(op_dict)
 
         elif 'fused_op' in op and op["fused_op"]["name"] == layer:
@@ -779,12 +822,16 @@ def create_tensor_metadata_json(layer, params_dict):
                 if "add" in fused_op_name:
                     tensor_metadata["has_residual"] = True
                 fused_op_dict["kwargs"] = fused_op["kwargs"]
+                # Should be if "conv2d" or if "matmul", etc. Generalize this in the future
+                if "conv2d" in fused_op_dict["name"]:
+                    append_glb_base_addresses(fused_op_dict["kwargs"], mu_glb_base_address)
                 for arg_key in fused_op_dict["kwargs"]:
                     arg = fused_op_dict["kwargs"][arg_key]
                     tensor = arg.get("tensor")
-                    # Remove memory field from voyager compiler (mapping to GLB memory is different and handled in the aha flow)
                     if isinstance(tensor, dict):
-                        tensor.pop("memory", None)
+                        if "memory" in tensor:
+                            del tensor["memory"]  # Remove memory field from voyager compiler (mapping to GLB memory is different and handled in the aha flow)
+
                 tensor_metadata["ops"].append(fused_op_dict)
 
         if match:

--- a/run_regression.py
+++ b/run_regression.py
@@ -745,7 +745,8 @@ def add_layers(network, layers, layer_counts, uniquify):
 def append_glb_base_addresses(kwargs, mu_glb_base_address):
 
     # FIXME: Temporary HACK
-    reduction_kernel_hack = False
+    zircon_cgra_psum_workaround = "ZIRCON_CGRA_PSUM_WORKAROUND" in os.environ and os.environ["ZIRCON_CGRA_PSUM_WORKAROUND"] == "1"
+    num_psums = "NUM_PSUMS" in os.environ and int(os.environ["NUM_PSUMS"]) if zircon_cgra_psum_workaround else 1
     kernel_and_stride_hack = "KERNEL_AND_STRIDE_HACK" in os.environ and os.environ["KERNEL_AND_STRIDE_HACK"] == "1"
 
     # Append GLB base addresses to the kwargs for input, weight, bias, inputScale, and weightScale tensors
@@ -753,25 +754,25 @@ def append_glb_base_addresses(kwargs, mu_glb_base_address):
 
     # multiply all element in kwargs['input']['tensor']['shape'] together and add to input_base_address
     input_num_elements = functools.reduce(operator.mul, kwargs['input']['tensor']['shape'], 1)
-    if reduction_kernel_hack:
-        input_num_elements /= 2
+    if zircon_cgra_psum_workaround:
+        input_num_elements /= num_psums
     inputScale_base_address = input_base_address + math.ceil(input_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
 
     inputScale_num_elements = functools.reduce(operator.mul, kwargs['input_scale']['tensor']['shape'], 1)
-    if reduction_kernel_hack:
-        inputScale_num_elements /= 2
+    if zircon_cgra_psum_workaround:
+        inputScale_num_elements /= num_psums
     weight_base_address = inputScale_base_address + math.ceil(inputScale_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
 
     weight_num_elements = functools.reduce(operator.mul, kwargs['weight']['tensor']['shape'], 1)
-    if reduction_kernel_hack:
-        weight_num_elements /= 2
+    if zircon_cgra_psum_workaround:
+        weight_num_elements /= num_psums
     if kernel_and_stride_hack:
         weight_num_elements *= 3 * 3
     weightScale_base_address = weight_base_address + math.ceil(weight_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
 
     weightScale_num_elements = functools.reduce(operator.mul, kwargs['weight_scale']['tensor']['shape'], 1)
-    if reduction_kernel_hack:
-        weightScale_num_elements /= 2
+    if zircon_cgra_psum_workaround:
+        weightScale_num_elements /= num_psums
     if kernel_and_stride_hack:
         weightScale_num_elements *= 3 * 3
 

--- a/scripts/aha_flow/compare_load_data.py
+++ b/scripts/aha_flow/compare_load_data.py
@@ -1,3 +1,33 @@
+import numpy as np
+
+
+def bfbin2float(bfstr):
+    sign = bfstr[0]
+    exp = bfstr[1:9]
+    lfrac = bfstr[9:16]
+    if sign == "0" and exp == "11111111" and lfrac != "0000000":
+        return float('nan')
+    elif sign == "1" and exp == "11111111" and lfrac != "0000000":
+        return -float('nan')
+    elif sign == "0" and exp == "11111111" and lfrac == "0000000":
+        return float('inf')
+    elif sign == "1" and exp == "11111111" and lfrac == "0000000":
+        return -float('inf')
+    elif sign == "0" and exp == "00000000" and lfrac == "0000000":
+        return float(0)
+    elif sign == "1" and exp == "00000000" and lfrac == "0000000":
+        return -float(0)
+    else:
+        mult = 1
+        if sign == "1":
+            mult = -1
+        nexp = int(exp, 2) - 127
+        if exp != 0:
+            lfrac = "1" + lfrac
+        else:
+            lfrac = "0" + lfrac
+        nfrac = int(lfrac, 2)
+        return mult * nfrac * (2 ** (nexp - 7))
 
 def read_bytes_from_waveform(file_path):
     all_bytes = []
@@ -26,19 +56,19 @@ def read_bytes_from_systemC(file_path):
     return all_bytes
 
 def read_bytes_from_hw_output_txt(file_path):
-    all_bytes = []
+    float_array = []
 
     with open(file_path, "r") as file:
+        hex_array = []
+
         for line in file:
-            values = line.strip().split()
-            for hex_pair in values:
-                msb = hex_pair[:2]
-                lsb = hex_pair[2:]
-                # all_bytes.append(int(lsb, 16))
-                # all_bytes.append(int(msb, 16))
-                all_bytes.append(lsb)
-                all_bytes.append(msb)
-    return all_bytes
+            if line.strip():  # Check if the line is not empty
+                values = [int(value, 16) for value in line.split()]
+                hex_array.extend(values)
+
+    # float_array = np.array(all_bytes, dtype=np.float32)
+    float_array = np.array([bfbin2float(bin(x)[2:].zfill(16)) for x in hex_array], dtype=np.float32)
+    return float_array
 
 
 # Compare the two lists
@@ -55,33 +85,69 @@ def compare_data(data1, data2, name):
 
 
 
+def read_SA_output_from_systemC(input_txt_path):
+    float_list = []
+
+    with open(input_txt_path, 'r') as f:
+        for line in f:
+            if line.strip():  # Skip empty lines just in case
+                floats = [np.float32(x) for x in line.strip().split()]
+                float_list.extend(floats)
+
+    float_array = np.array(float_list, dtype=np.float32)
+
+    return float_array
+
+
+def compare_floating_point_data(data1, data2, name):
+    if len(data1) != len(data2):
+        print(f"Length mismatch in {name}: {len(data1)} vs {len(data2)}")
+
+    for i in range(len(data1)):
+        if not np.isclose(data1[i], data2[i], rtol=1e-05, atol=1e-08):
+            print(f"Mismatch in {name} at index {i}: {data1[i]} vs {data2[i]}")
+
+    print(f"{name} match!")
+
+
+
 if __name__ == "__main__":
-    input_data_mu_in = read_bytes_from_waveform("/aha/garnet/tests/test_app/input_data_mu_in.txt")
-    weight_data_mu_in = read_bytes_from_waveform("/aha/garnet/tests/test_app/weight_data_mu_in.txt")
-    bias_data_mu_in = read_bytes_from_waveform("/aha/garnet/tests/test_app/bias_data_mu_in.txt")
-    inputScale_data_mu_in = read_bytes_from_waveform("/aha/garnet/tests/test_app/inputScale_data_mu_in.txt")
-    weightScale_data_mu_in = read_bytes_from_waveform("/aha/garnet/tests/test_app/weightScale_data_mu_in.txt")
+    # input_data_mu_in = read_bytes_from_waveform("/aha/garnet/tests/test_app/input_data_mu_in.txt")
+    # weight_data_mu_in = read_bytes_from_waveform("/aha/garnet/tests/test_app/weight_data_mu_in.txt")
+    # bias_data_mu_in = read_bytes_from_waveform("/aha/garnet/tests/test_app/bias_data_mu_in.txt")
+    # inputScale_data_mu_in = read_bytes_from_waveform("/aha/garnet/tests/test_app/inputScale_data_mu_in.txt")
+    # weightScale_data_mu_in = read_bytes_from_waveform("/aha/garnet/tests/test_app/weightScale_data_mu_in.txt")
 
-    # systolic_array_data_out = read_bytes_from_waveform("/aha/garnet/tests/test_app/systolic_array_output.txt")
-    # print(len(systolic_array_data_out))
-
-
-    input_data_systemC = read_bytes_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_6/compare/input_data_systemC.txt")
-    weight_data_systemC = read_bytes_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_6/compare/weight_data_systemC.txt")
-    bias_data_systemC = read_bytes_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_6/compare/bias_data_systemC.txt")
-    inputScale_data_systemC = read_bytes_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_6/compare/inputScale_data_systemC.txt")
-    weightScale_data_systemC = read_bytes_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_6/compare/weightScale_data_systemC.txt")
-
-    # glb_hw_output = read_bytes_from_hw_output_txt("/aha/garnet/tests/test_app/hw_output.txt")
+    # # systolic_array_data_out = read_bytes_from_waveform("/aha/garnet/tests/test_app/systolic_array_output.txt")
+    # # print(len(systolic_array_data_out))
 
 
-    compare_data(input_data_mu_in, input_data_systemC, "input_data")
-    compare_data(weight_data_mu_in, weight_data_systemC, "weight_data")
-    compare_data(bias_data_mu_in, bias_data_systemC, "bias_data")
-    compare_data(inputScale_data_mu_in, inputScale_data_systemC, "inputScale_data")
-    compare_data(weightScale_data_mu_in, weightScale_data_systemC, "weightScale_data")
+    # input_data_systemC = read_bytes_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_6/compare/input_data_systemC.txt")
+    # weight_data_systemC = read_bytes_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_6/compare/weight_data_systemC.txt")
+    # bias_data_systemC = read_bytes_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_6/compare/bias_data_systemC.txt")
+    # inputScale_data_systemC = read_bytes_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_6/compare/inputScale_data_systemC.txt")
+    # weightScale_data_systemC = read_bytes_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_6/compare/weightScale_data_systemC.txt")
 
-    # compare_data(systolic_array_data_out, glb_hw_output, "systolic_array_output")
+    SA_output_systemC = read_SA_output_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_10/compare/SA_output_systemC.txt")
+
+
+
+    glb_hw_output = read_bytes_from_hw_output_txt("/aha/garnet/tests/test_app/hw_output.txt")
+
+    # Reshape it to (Y1, Y0, X1, X0, K2, K1, K0=32)
+    glb_hw_output = glb_hw_output.reshape((2, 7, 1, 14, 8, 1, 32))
+    glb_hw_output = glb_hw_output.transpose(2, 4, 0, 5, 1, 3, 6)  # (X0, K2, Y1, K1, Y0, X0, K0=32)
+    glb_hw_output = glb_hw_output.flatten()  # Flatten to 1D array
+
+
+    # compare_data(input_data_mu_in, input_data_systemC, "input_data")
+    # compare_data(weight_data_mu_in, weight_data_systemC, "weight_data")
+    # compare_data(bias_data_mu_in, bias_data_systemC, "bias_data")
+    # compare_data(inputScale_data_mu_in, inputScale_data_systemC, "inputScale_data")
+    # compare_data(weightScale_data_mu_in, weightScale_data_systemC, "weightScale_data")
+
+
+    compare_floating_point_data(SA_output_systemC, glb_hw_output, "systolic_array_output_float")
 
 
 

--- a/scripts/aha_flow/compare_load_data.py
+++ b/scripts/aha_flow/compare_load_data.py
@@ -128,15 +128,15 @@ if __name__ == "__main__":
     # inputScale_data_systemC = read_bytes_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_6/compare/inputScale_data_systemC.txt")
     # weightScale_data_systemC = read_bytes_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_6/compare/weightScale_data_systemC.txt")
 
-    SA_output_systemC = read_SA_output_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_10/compare/SA_output_systemC.txt")
+    SA_output_systemC = read_SA_output_from_systemC("/aha/SA_output_systemC.txt")
 
 
 
     glb_hw_output = read_bytes_from_hw_output_txt("/aha/garnet/tests/test_app/hw_output.txt")
 
     # Reshape it to (Y1, Y0, X1, X0, K2, K1, K0=32)
-    glb_hw_output = glb_hw_output.reshape((2, 7, 1, 14, 8, 1, 32))
-    glb_hw_output = glb_hw_output.transpose(2, 4, 0, 5, 1, 3, 6)  # (X0, K2, Y1, K1, Y0, X0, K0=32)
+    glb_hw_output = glb_hw_output.reshape((1, 14, 1, 14, 8, 1, 32))
+    glb_hw_output = glb_hw_output.transpose(0, 2, 4, 5, 1, 3, 6)  # (Y1, X1, K2, K1, Y0, X0, K0=32)
     glb_hw_output = glb_hw_output.flatten()  # Flatten to 1D array
 
 

--- a/scripts/aha_flow/glb_dma_config.py
+++ b/scripts/aha_flow/glb_dma_config.py
@@ -1,3 +1,4 @@
+import os
 # This code is used to generate the GLB affine controller config for a specific tiling pattern in a neural network layer.
 
 arg_indices_dict = {
@@ -114,7 +115,7 @@ def get_glb_dma_config_helper(loop_order, loop_bounds):
     return dimensionality, trimmed_strides, trimmed_extents
 
 
-def get_glb_dma_config(output_tiling_filepath: str):
+def get_glb_dma_config(output_tiling_filepath: str, kernel_and_stride_hack: bool = False):
     """
     Reads the tiling file and returns the GLB DMA config.
     The tiling file should contain the loop order and loop bounds in a specific format.
@@ -138,6 +139,10 @@ def get_glb_dma_config(output_tiling_filepath: str):
         loop_bounds[3] = outer_loops[y_loop_indices[0]]  # Y1
         loop_bounds[4] = inner_loops[k_loop_indices[1]]  # K1
         loop_bounds[5] = outer_loops[k_loop_indices[0]]  # K2
+
+        if kernel_and_stride_hack:
+            loop_bounds[0] = loop_bounds[0] // 2 # divide X0 by 2 to account for the hack; actual output is 2x smaller than what MU produces
+            loop_bounds[1] = loop_bounds[1] // 2 # divide Y0 by 2 to account for the hack; actual output is 2x smaller than what MU produces
 
         # Construct loop order based on the indices
         # Map variable names to their values

--- a/scripts/aha_flow/glb_dma_config.py
+++ b/scripts/aha_flow/glb_dma_config.py
@@ -115,7 +115,7 @@ def get_glb_dma_config_helper(loop_order, loop_bounds):
     return dimensionality, trimmed_strides, trimmed_extents
 
 
-def get_glb_dma_config(output_tiling_filepath: str, kernel_and_stride_hack: bool = False):
+def get_glb_dma_config(output_tiling_filepath: str, zircon_fx_fy_stride_workaround: bool = False):
     """
     Reads the tiling file and returns the GLB DMA config.
     The tiling file should contain the loop order and loop bounds in a specific format.
@@ -140,7 +140,7 @@ def get_glb_dma_config(output_tiling_filepath: str, kernel_and_stride_hack: bool
         loop_bounds[4] = inner_loops[k_loop_indices[1]]  # K1
         loop_bounds[5] = outer_loops[k_loop_indices[0]]  # K2
 
-        if kernel_and_stride_hack:
+        if zircon_fx_fy_stride_workaround:
             loop_bounds[0] = loop_bounds[0] // 2 # divide X0 by 2 to account for the hack; actual output is 2x smaller than what MU produces
             loop_bounds[1] = loop_bounds[1] // 2 # divide Y0 by 2 to account for the hack; actual output is 2x smaller than what MU produces
 

--- a/scripts/aha_flow/parse_dnnLayer_tensors.py
+++ b/scripts/aha_flow/parse_dnnLayer_tensors.py
@@ -101,6 +101,22 @@ def write_all_tensors_to_hex(
             write_list_to_hex(residual_bf16, output_dir + 'residual_hex.txt', residual_start_addr)
 
 
+# For writing partial sum output from a prior kernel to raw binary file
+def hw_output_txt_to_raw(input_txt_path, output_raw_path):
+    # Read the file content
+    with open(input_txt_path, 'r') as f:
+        hex_values = f.read().split()
+
+    # Convert hex strings to unsigned 16-bit integers
+    uint16_array = np.array([int(h, 16) for h in hex_values], dtype=np.uint16)
+
+    # Swap byte order
+    uint16_array_be = uint16_array.byteswap().newbyteorder('>')
+
+    # Save to raw binary file
+    uint16_array_be.tofile(output_raw_path)
+
+
 def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
     # Base path for the binary files
     base_path = f'/aha/voyager/test/compiler/networks/{model}/{datatype}/tensor_files/'
@@ -133,14 +149,27 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
 
     mu_glb_base_addr = tensor_metadata["mu_glb_base_address"]
 
+    # FIXME: Temporary HACK
+    hack_kernel0 = False
+    hack_kernel1 = True
+
+    hack_index = 0
+    if hack_kernel1:
+        hack_index = 1
+
+
     # INPUT
     # Shape is in format: (OC, IC, Y, X)
     input = read_tensor(base_path + input_tensor_data["node"] + ".bin",
                         (input_tensor_data["shape"][0], input_tensor_data["shape"][1], input_tensor_data["shape"][2], input_tensor_data["shape"][3]))
     # Re-order it so IC is the innermost dimension (Y, X, OC, IC)
     input_reordered = input.permute(2, 3, 0, 1)
+    if hack_kernel0 or hack_kernel1:
+        input_reordered = input_reordered.reshape((input_tensor_data["shape"][2], input_tensor_data["shape"][3], input_tensor_data["shape"][0], input_tensor_data["shape"][1] // 64, 64))
+        input_reordered = input_reordered.permute(3, 0, 1, 2, 4)
+        input_reordered = input_reordered[hack_index]
     input_int8 = input_reordered.to(torch.int8)
-    input_start_addr = mu_glb_base_addr # starting address in the GLB for input tensor. Rest of tensors are stored contiguously in the GLB memory
+    input_start_addr = input_tensor_data["glb_base_address"]
 
     # INPUT SCALE
     # Shape is in format: (OC, IC / BLOCK_SIZE, Y, X)
@@ -148,8 +177,11 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
                              (inputScale_tensor_data["shape"][0], inputScale_tensor_data["shape"][1], inputScale_tensor_data["shape"][2], inputScale_tensor_data["shape"][3]))
     # Re-order it so IC is the innermost dimension (Y, X, OC, IC / BLOCK_SIZE)
     inputScale_reordered = inputScale.permute(2, 3, 0, 1)
+    if hack_kernel0 or hack_kernel1:
+        inputScale_reordered = inputScale_reordered.permute(3, 0, 1, 2)
+        inputScale_reordered = inputScale_reordered[hack_index]
     inputScale_e8m0 = float_to_e8m0(inputScale_reordered)
-    inputScale_start_addr = input_start_addr + math.ceil(input_int8.numel()/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
+    inputScale_start_addr = inputScale_tensor_data["glb_base_address"]
 
     # WEIGHT
     # Shape is in format: (OC, IC, FY, FX)
@@ -157,8 +189,12 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
                          (weight_tensor_data["shape"][0], weight_tensor_data["shape"][1], weight_tensor_data["shape"][2], weight_tensor_data["shape"][3]))
     # Re-order it so OC is the innermost dimension (FY, FX, IC, OC)
     weight_reordered = weight.permute(2, 3, 1, 0)
+    if hack_kernel0 or hack_kernel1:
+        weight_reordered = weight_reordered.reshape((weight_tensor_data["shape"][2], weight_tensor_data["shape"][3], weight_tensor_data["shape"][1] // 64, 64, weight_tensor_data["shape"][0]))
+        weight_reordered = weight_reordered.permute(2, 0, 1, 3, 4)
+        weight_reordered = weight_reordered[hack_index]
     weight_int8 = weight_reordered.to(torch.int8)
-    weight_start_addr = inputScale_start_addr + math.ceil(inputScale_e8m0.size/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
+    weight_start_addr = weight_tensor_data["glb_base_address"]
 
     # WEIGHT SCALE
     # Shape is in format: (OC, IC / BLOCK_SIZE, FY, FX)
@@ -166,13 +202,20 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
                               (weightScale_tensor_data["shape"][0], weightScale_tensor_data["shape"][1], weightScale_tensor_data["shape"][2], weightScale_tensor_data["shape"][3]))
     # Re-order it so OC is the innermost dimension (FY, FX, IC / BLOCK_SIZE, OC)
     weightScale_reordered = weightScale.permute(2, 3, 1, 0)
+    if hack_kernel0 or hack_kernel1:
+        weightScale_reordered = weightScale_reordered.permute(2, 0, 1, 3)
+        weightScale_reordered = weightScale_reordered[hack_index]
     weightScale_e8m0 = float_to_e8m0(weightScale_reordered)
-    weightScale_start_addr = weight_start_addr + math.ceil(weight.numel()/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
+    weightScale_start_addr = weightScale_tensor_data["glb_base_address"]
 
     # BIAS
     bias = read_tensor(base_path + bias_tensor_data["node"] + ".bin", (bias_tensor_data["shape"][0]))
+    if hack_kernel1:
+        # Set bias to all 0s
+        bias = torch.zeros((bias_tensor_data["shape"][0],), dtype=torch.float32)
     bias_bf16 = float32_to_bfloat16_bits(bias)
-    bias_start_addr = weightScale_start_addr + math.ceil(weightScale_e8m0.size/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
+    bias_start_addr = bias_tensor_data["glb_base_address"]
+
 
     # RESIDUAL
     # Shape is in format: (OC, IC, Y, X)
@@ -190,6 +233,13 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
         residual_bf16 = residual_bf16.flatten().tolist()
 
     torch.set_printoptions(precision=10)
+
+    # FIXME: Temporary HACK
+    # PARTIAL SUM (MU reduction workaround)
+    if hack_kernel1:
+        hw_output_txt_path = f'/aha/garnet/tests/hw_output_pass0.txt'
+        hw_output_raw_path = f'{h2h_dir}/hw_partial_sum_input_stencil.raw'
+        hw_output_txt_to_raw(hw_output_txt_path, hw_output_raw_path)
 
     if debug_mode:
         debug_print_tensors(

--- a/scripts/aha_flow/parse_dnnLayer_tensors.py
+++ b/scripts/aha_flow/parse_dnnLayer_tensors.py
@@ -156,7 +156,7 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
     num_psums = "NUM_PSUMS" in os.environ and int(os.environ["NUM_PSUMS"]) if zircon_cgra_psum_workaround else 1
 
     if zircon_cgra_psum_workaround:
-        print(f"\033[93mINFO: Zircon CGRA PSUM workaround enabled to avoid MU bug on downsample layers. Using PSUM index {psum_idx} out of {num_psums} total PSUMs.\033[0m")
+        print(f"\033[93mINFO: Zircon CGRA PSUM workaround enabled to avoid MU bug on downsample layers. Using PSUM index {psum_idx}. There are {num_psums} total PSUMs.\033[0m")
 
     if zircon_fx_fy_stride_workaround:
         print("\033[93mINFO: Zircon FX, FY stride workaround enabled to avoid MU bug on downsample layers.\033[0m")
@@ -250,7 +250,8 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
 
     # For psum_workoround, if not kernel 0, read prior kernel output from text file and convert to raw binary file
     if zircon_cgra_psum_workaround and (psum_idx != 0):
-        hw_output_txt_path = f'/aha/garnet/tests/test_app/hw_output.txt'
+        hw_output_txt_path = f'/aha/Halide-to-Hardware/apps/hardware_benchmarks/apps/zircon_psum_reduction_fp/{model}-{layer}_gold/kernel_{psum_idx - 1}_output.txt'
+        assert os.path.exists(hw_output_txt_path), f"The prior kernel output file {hw_output_txt_path} does not exist."
         # For the last psum, write to hw_residual_input_stencil.raw, otherwise write to hw_partial_sum_input_stencil.raw
         if psum_idx == (num_psums - 1):
             hw_output_raw_path = f'{h2h_dir}/hw_residual_input_stencil.raw'

--- a/scripts/aha_flow/parse_dnnLayer_tensors.py
+++ b/scripts/aha_flow/parse_dnnLayer_tensors.py
@@ -151,7 +151,10 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
 
     # FIXME: Temporary HACK
     hack_kernel0 = False
-    hack_kernel1 = True
+    hack_kernel1 = False
+
+    # FIXME: Temporary HACK
+    kernel_and_stride_hack = "KERNEL_AND_STRIDE_HACK" in os.environ and os.environ["KERNEL_AND_STRIDE_HACK"] == "1"
 
     hack_index = 0
     if hack_kernel1:
@@ -187,6 +190,8 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
     # Shape is in format: (OC, IC, FY, FX)
     weight = read_tensor(base_path + weight_tensor_data["node"] + ".bin",
                          (weight_tensor_data["shape"][0], weight_tensor_data["shape"][1], weight_tensor_data["shape"][2], weight_tensor_data["shape"][3]))
+    if kernel_and_stride_hack:
+        weight = F.pad(weight, pad=(0, 2, 0, 2))
     # Re-order it so OC is the innermost dimension (FY, FX, IC, OC)
     weight_reordered = weight.permute(2, 3, 1, 0)
     if hack_kernel0 or hack_kernel1:
@@ -200,6 +205,8 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
     # Shape is in format: (OC, IC / BLOCK_SIZE, FY, FX)
     weightScale = read_tensor(base_path + weightScale_tensor_data["node"] + ".bin",
                               (weightScale_tensor_data["shape"][0], weightScale_tensor_data["shape"][1], weightScale_tensor_data["shape"][2], weightScale_tensor_data["shape"][3]))
+    if kernel_and_stride_hack:
+        weightScale = F.pad(weightScale, pad=(0, 2, 0, 2))
     # Re-order it so OC is the innermost dimension (FY, FX, IC / BLOCK_SIZE, OC)
     weightScale_reordered = weightScale.permute(2, 3, 1, 0)
     if hack_kernel0 or hack_kernel1:
@@ -222,6 +229,12 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
     if has_residual:
         residual = read_tensor(base_path + residual_tensor_data["node"] + ".bin",
                                (residual_tensor_data["shape"][0], residual_tensor_data["shape"][1], residual_tensor_data["shape"][2], residual_tensor_data["shape"][3]))
+
+        if kernel_and_stride_hack:
+            residual_tmp = torch.zeros(residual.size(0), residual.size(1), 2*residual.size(2), 2*residual.size(3), device=residual.device, dtype=residual.dtype)
+            # Place original values at odd indices (1, 3, 5, ...) using slicing
+            residual_tmp[:, :, 1::2, 1::2] = residual
+            residual = residual_tmp
 
         # Re-order it so IC is the innermost dimension (Y, X, OC, IC)
         residual_reordered = residual.permute(2, 3, 0, 1)
@@ -265,3 +278,16 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
         has_residual=has_residual,
         residual_bf16=residual_bf16 if has_residual else None
     )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Parse DNN layer tensors from binary files and convert them to hex files.')
+    parser.add_argument('--model', type=str, required=True, help='Model name (e.g., resnet18)')
+    parser.add_argument('--layer', type=str, required=True, help='Layer name (e.g., conv2d_mx_default_11)')
+    parser.add_argument('--datatype', type=str, default='MXINT8', help='Data type of the tensors')
+    parser.add_argument('--h2h_dir', type=str, required=True, default='/aha/Halide-to-Hardware/', help='Path to Halide-to-Hardware directory')
+    parser.add_argument('--debug', action='store_true', help='Enable debug mode to print tensor values')
+
+    args = parser.parse_args()
+
+    parse_tensors(args.model, args.layer, args.datatype, args.h2h_dir, args.debug)

--- a/scripts/aha_flow/parse_dnnLayer_tensors.py
+++ b/scripts/aha_flow/parse_dnnLayer_tensors.py
@@ -228,7 +228,11 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
         residual_bf16 = float32_to_bfloat16_bits(residual_reordered)
         residual_bf16_be = residual_bf16.byteswap().newbyteorder('>')
 
-        residual_bf16_be.tofile(f'{h2h_dir}/hw_residual_input_stencil.raw')
+        # FIXME: Temporary HACK
+        if hack_kernel0:
+            residual_bf16_be.tofile(f'{h2h_dir}/hw_partial_sum_input_stencil.raw')
+        else:
+            residual_bf16_be.tofile(f'{h2h_dir}/hw_residual_input_stencil.raw')
         # Flatten residual_bf16 and convert to a python list
         residual_bf16 = residual_bf16.flatten().tolist()
 
@@ -237,8 +241,8 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
     # FIXME: Temporary HACK
     # PARTIAL SUM (MU reduction workaround)
     if hack_kernel1:
-        hw_output_txt_path = f'/aha/garnet/tests/hw_output_pass0.txt'
-        hw_output_raw_path = f'{h2h_dir}/hw_partial_sum_input_stencil.raw'
+        hw_output_txt_path = f'/aha/garnet/tests/hw_output_kernel0.txt'
+        hw_output_raw_path = f'{h2h_dir}/hw_residual_input_stencil.raw'
         hw_output_txt_to_raw(hw_output_txt_path, hw_output_raw_path)
 
     if debug_mode:

--- a/scripts/aha_flow/parse_dnnLayer_tensors.py
+++ b/scripts/aha_flow/parse_dnnLayer_tensors.py
@@ -149,11 +149,17 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
 
     mu_glb_base_addr = tensor_metadata["mu_glb_base_address"]
 
-    # FIXME: Temporary HACK
-    kernel_and_stride_hack = "KERNEL_AND_STRIDE_HACK" in os.environ and os.environ["KERNEL_AND_STRIDE_HACK"] == "1"
+    # Workarounds to avoid Zircon MU bug on Resnet downsample layers
+    zircon_fx_fy_stride_workaround = "ZIRCON_FX_FY_STRIDE_WORKAROUND" in os.environ and os.environ["ZIRCON_FX_FY_STRIDE_WORKAROUND"] == "1"
     zircon_cgra_psum_workaround = "ZIRCON_CGRA_PSUM_WORKAROUND" in os.environ and os.environ["ZIRCON_CGRA_PSUM_WORKAROUND"] == "1"
     psum_idx = "PSUM_IDX" in os.environ and int(os.environ["PSUM_IDX"]) if zircon_cgra_psum_workaround else 1
     num_psums = "NUM_PSUMS" in os.environ and int(os.environ["NUM_PSUMS"]) if zircon_cgra_psum_workaround else 1
+
+    if zircon_cgra_psum_workaround:
+        print(f"\033[93mINFO: Zircon CGRA PSUM workaround enabled to avoid MU bug on downsample layers. Using PSUM index {psum_idx} out of {num_psums} total PSUMs.\033[0m")
+
+    if zircon_fx_fy_stride_workaround:
+        print("\033[93mINFO: Zircon FX, FY stride workaround enabled to avoid MU bug on downsample layers.\033[0m")
 
     # INPUT
     # Shape is in format: (OC, IC, Y, X)
@@ -164,7 +170,6 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
     if zircon_cgra_psum_workaround:
         input_reordered = input_reordered.reshape((input_tensor_data["shape"][2], input_tensor_data["shape"][3], input_tensor_data["shape"][0], input_tensor_data["shape"][1] // 64, 64))
         input_reordered = input_reordered.permute(3, 0, 1, 2, 4)
-        input_reordered = input_reordered[psum_idx]
     input_int8 = input_reordered.to(torch.int8)
     input_start_addr = input_tensor_data["glb_base_address"]
 
@@ -176,7 +181,6 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
     inputScale_reordered = inputScale.permute(2, 3, 0, 1)
     if zircon_cgra_psum_workaround:
         inputScale_reordered = inputScale_reordered.permute(3, 0, 1, 2)
-        inputScale_reordered = inputScale_reordered[psum_idx]
     inputScale_e8m0 = float_to_e8m0(inputScale_reordered)
     inputScale_start_addr = inputScale_tensor_data["glb_base_address"]
 
@@ -184,14 +188,14 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
     # Shape is in format: (OC, IC, FY, FX)
     weight = read_tensor(base_path + weight_tensor_data["node"] + ".bin",
                          (weight_tensor_data["shape"][0], weight_tensor_data["shape"][1], weight_tensor_data["shape"][2], weight_tensor_data["shape"][3]))
-    if kernel_and_stride_hack:
+    if zircon_fx_fy_stride_workaround:
         weight = F.pad(weight, pad=(0, 2, 0, 2))
     # Re-order it so OC is the innermost dimension (FY, FX, IC, OC)
     weight_reordered = weight.permute(2, 3, 1, 0)
     if zircon_cgra_psum_workaround:
         weight_reordered = weight_reordered.reshape((weight_tensor_data["shape"][2], weight_tensor_data["shape"][3], weight_tensor_data["shape"][1] // 64, 64, weight_tensor_data["shape"][0]))
         weight_reordered = weight_reordered.permute(2, 0, 1, 3, 4)
-        weight_reordered = weight_reordered[psum_idx]
+        # weight_reordered = weight_reordered[psum_idx]
     weight_int8 = weight_reordered.to(torch.int8)
     weight_start_addr = weight_tensor_data["glb_base_address"]
 
@@ -199,13 +203,12 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
     # Shape is in format: (OC, IC / BLOCK_SIZE, FY, FX)
     weightScale = read_tensor(base_path + weightScale_tensor_data["node"] + ".bin",
                               (weightScale_tensor_data["shape"][0], weightScale_tensor_data["shape"][1], weightScale_tensor_data["shape"][2], weightScale_tensor_data["shape"][3]))
-    if kernel_and_stride_hack:
+    if zircon_fx_fy_stride_workaround:
         weightScale = F.pad(weightScale, pad=(0, 2, 0, 2))
     # Re-order it so OC is the innermost dimension (FY, FX, IC / BLOCK_SIZE, OC)
     weightScale_reordered = weightScale.permute(2, 3, 1, 0)
     if zircon_cgra_psum_workaround:
         weightScale_reordered = weightScale_reordered.permute(2, 0, 1, 3)
-        weightScale_reordered = weightScale_reordered[psum_idx]
     weightScale_e8m0 = float_to_e8m0(weightScale_reordered)
     weightScale_start_addr = weightScale_tensor_data["glb_base_address"]
 
@@ -224,7 +227,7 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
         residual = read_tensor(base_path + residual_tensor_data["node"] + ".bin",
                                (residual_tensor_data["shape"][0], residual_tensor_data["shape"][1], residual_tensor_data["shape"][2], residual_tensor_data["shape"][3]))
 
-        if kernel_and_stride_hack:
+        if zircon_fx_fy_stride_workaround:
             residual_tmp = torch.zeros(residual.size(0), residual.size(1), 2*residual.size(2), 2*residual.size(3), device=residual.device, dtype=residual.dtype)
             # Place original values at odd indices (1, 3, 5, ...) using slicing
             residual_tmp[:, :, 1::2, 1::2] = residual
@@ -235,7 +238,6 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
         residual_bf16 = float32_to_bfloat16_bits(residual_reordered)
         residual_bf16_be = residual_bf16.byteswap().newbyteorder('>')
 
-        # FIXME: Temporary HACK
         if zircon_cgra_psum_workaround and (psum_idx == 0):
             residual_bf16_be.tofile(f'{h2h_dir}/hw_partial_sum_input_stencil.raw')
         # Write the residual_bf16_be to a raw file except for psum workaround middle kernels
@@ -246,11 +248,14 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
 
     torch.set_printoptions(precision=10)
 
-    # FIXME: Temporary HACK
     # For psum_workoround, if not kernel 0, read prior kernel output from text file and convert to raw binary file
     if zircon_cgra_psum_workaround and (psum_idx != 0):
         hw_output_txt_path = f'/aha/garnet/tests/test_app/hw_output.txt'
-        hw_output_raw_path = f'{h2h_dir}/hw_residual_input_stencil.raw'
+        # For the last psum, write to hw_residual_input_stencil.raw, otherwise write to hw_partial_sum_input_stencil.raw
+        if psum_idx == (num_psums - 1):
+            hw_output_raw_path = f'{h2h_dir}/hw_residual_input_stencil.raw'
+        else:
+            hw_output_raw_path = f'{h2h_dir}/hw_partial_sum_input_stencil.raw'
         hw_output_txt_to_raw(hw_output_txt_path, hw_output_raw_path)
 
     if debug_mode:

--- a/scripts/aha_flow/parse_dnnLayer_tensors.py
+++ b/scripts/aha_flow/parse_dnnLayer_tensors.py
@@ -150,16 +150,10 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
     mu_glb_base_addr = tensor_metadata["mu_glb_base_address"]
 
     # FIXME: Temporary HACK
-    hack_kernel0 = False
-    hack_kernel1 = False
-
-    # FIXME: Temporary HACK
     kernel_and_stride_hack = "KERNEL_AND_STRIDE_HACK" in os.environ and os.environ["KERNEL_AND_STRIDE_HACK"] == "1"
-
-    hack_index = 0
-    if hack_kernel1:
-        hack_index = 1
-
+    zircon_cgra_psum_workaround = "ZIRCON_CGRA_PSUM_WORKAROUND" in os.environ and os.environ["ZIRCON_CGRA_PSUM_WORKAROUND"] == "1"
+    psum_idx = "PSUM_IDX" in os.environ and int(os.environ["PSUM_IDX"]) if zircon_cgra_psum_workaround else 1
+    num_psums = "NUM_PSUMS" in os.environ and int(os.environ["NUM_PSUMS"]) if zircon_cgra_psum_workaround else 1
 
     # INPUT
     # Shape is in format: (OC, IC, Y, X)
@@ -167,10 +161,10 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
                         (input_tensor_data["shape"][0], input_tensor_data["shape"][1], input_tensor_data["shape"][2], input_tensor_data["shape"][3]))
     # Re-order it so IC is the innermost dimension (Y, X, OC, IC)
     input_reordered = input.permute(2, 3, 0, 1)
-    if hack_kernel0 or hack_kernel1:
+    if zircon_cgra_psum_workaround:
         input_reordered = input_reordered.reshape((input_tensor_data["shape"][2], input_tensor_data["shape"][3], input_tensor_data["shape"][0], input_tensor_data["shape"][1] // 64, 64))
         input_reordered = input_reordered.permute(3, 0, 1, 2, 4)
-        input_reordered = input_reordered[hack_index]
+        input_reordered = input_reordered[psum_idx]
     input_int8 = input_reordered.to(torch.int8)
     input_start_addr = input_tensor_data["glb_base_address"]
 
@@ -180,9 +174,9 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
                              (inputScale_tensor_data["shape"][0], inputScale_tensor_data["shape"][1], inputScale_tensor_data["shape"][2], inputScale_tensor_data["shape"][3]))
     # Re-order it so IC is the innermost dimension (Y, X, OC, IC / BLOCK_SIZE)
     inputScale_reordered = inputScale.permute(2, 3, 0, 1)
-    if hack_kernel0 or hack_kernel1:
+    if zircon_cgra_psum_workaround:
         inputScale_reordered = inputScale_reordered.permute(3, 0, 1, 2)
-        inputScale_reordered = inputScale_reordered[hack_index]
+        inputScale_reordered = inputScale_reordered[psum_idx]
     inputScale_e8m0 = float_to_e8m0(inputScale_reordered)
     inputScale_start_addr = inputScale_tensor_data["glb_base_address"]
 
@@ -194,10 +188,10 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
         weight = F.pad(weight, pad=(0, 2, 0, 2))
     # Re-order it so OC is the innermost dimension (FY, FX, IC, OC)
     weight_reordered = weight.permute(2, 3, 1, 0)
-    if hack_kernel0 or hack_kernel1:
+    if zircon_cgra_psum_workaround:
         weight_reordered = weight_reordered.reshape((weight_tensor_data["shape"][2], weight_tensor_data["shape"][3], weight_tensor_data["shape"][1] // 64, 64, weight_tensor_data["shape"][0]))
         weight_reordered = weight_reordered.permute(2, 0, 1, 3, 4)
-        weight_reordered = weight_reordered[hack_index]
+        weight_reordered = weight_reordered[psum_idx]
     weight_int8 = weight_reordered.to(torch.int8)
     weight_start_addr = weight_tensor_data["glb_base_address"]
 
@@ -209,16 +203,16 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
         weightScale = F.pad(weightScale, pad=(0, 2, 0, 2))
     # Re-order it so OC is the innermost dimension (FY, FX, IC / BLOCK_SIZE, OC)
     weightScale_reordered = weightScale.permute(2, 3, 1, 0)
-    if hack_kernel0 or hack_kernel1:
+    if zircon_cgra_psum_workaround:
         weightScale_reordered = weightScale_reordered.permute(2, 0, 1, 3)
-        weightScale_reordered = weightScale_reordered[hack_index]
+        weightScale_reordered = weightScale_reordered[psum_idx]
     weightScale_e8m0 = float_to_e8m0(weightScale_reordered)
     weightScale_start_addr = weightScale_tensor_data["glb_base_address"]
 
     # BIAS
     bias = read_tensor(base_path + bias_tensor_data["node"] + ".bin", (bias_tensor_data["shape"][0]))
-    if hack_kernel1:
-        # Set bias to all 0s
+    if zircon_cgra_psum_workaround and psum_idx != 0:
+        # If doing psum workaround, bias is zero for all but the 0th kernel
         bias = torch.zeros((bias_tensor_data["shape"][0],), dtype=torch.float32)
     bias_bf16 = float32_to_bfloat16_bits(bias)
     bias_start_addr = bias_tensor_data["glb_base_address"]
@@ -242,9 +236,10 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
         residual_bf16_be = residual_bf16.byteswap().newbyteorder('>')
 
         # FIXME: Temporary HACK
-        if hack_kernel0:
+        if zircon_cgra_psum_workaround and (psum_idx == 0):
             residual_bf16_be.tofile(f'{h2h_dir}/hw_partial_sum_input_stencil.raw')
-        else:
+        # Write the residual_bf16_be to a raw file except for psum workaround middle kernels
+        elif not(zircon_cgra_psum_workaround and psum_idx != (num_psums - 1)):
             residual_bf16_be.tofile(f'{h2h_dir}/hw_residual_input_stencil.raw')
         # Flatten residual_bf16 and convert to a python list
         residual_bf16 = residual_bf16.flatten().tolist()
@@ -252,9 +247,9 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
     torch.set_printoptions(precision=10)
 
     # FIXME: Temporary HACK
-    # PARTIAL SUM (MU reduction workaround)
-    if hack_kernel1:
-        hw_output_txt_path = f'/aha/garnet/tests/hw_output_kernel0.txt'
+    # For psum_workoround, if not kernel 0, read prior kernel output from text file and convert to raw binary file
+    if zircon_cgra_psum_workaround and (psum_idx != 0):
+        hw_output_txt_path = f'/aha/garnet/tests/test_app/hw_output.txt'
         hw_output_raw_path = f'{h2h_dir}/hw_residual_input_stencil.raw'
         hw_output_txt_to_raw(hw_output_txt_path, hw_output_raw_path)
 

--- a/src/MatrixProcessor.h
+++ b/src/MatrixProcessor.h
@@ -476,6 +476,17 @@ SC_MODULE(MatrixProcessor) {
           BufferWriteRequest<Pack1D<Buffer, NCols>> req;
           req.address = writeAddress;
           req.data = previous_accumulation;
+
+        // --------------DATA DUMPING FOR AHA FLOW-------------------//
+        std::ofstream SA_psum_output_file;
+        SA_psum_output_file.open("SA_psum_systemC.txt", std::ios::app);
+        if (!SA_psum_output_file.is_open()) {
+          spdlog::error("Failed to open SA_psum_systemC.txt for writing.");
+          return;
+        }
+        SA_psum_output_file << previous_accumulation << std::endl;
+        // --------------DATA DUMPING FOR AHA FLOW-------------------//
+
           accumulation_buffer_write_request[accumulation_buffer_bank].Push(req);
         }
 

--- a/test/common/Harness.cc
+++ b/test/common/Harness.cc
@@ -461,7 +461,13 @@ void Harness::sendParams() {
 
     std::deque<AcceleratorMemoryMap> accelerator_memory_maps;
     std::deque<BaseParams *> accelerator_params;
-    MapOperation(currentOperation, accelerator_params, accelerator_memory_maps);
+    MapOperation(currentOperation, accelerator_params, accelerator_memory_maps, false, false);
+
+    std::deque<AcceleratorMemoryMap> dump_accelerator_memory_maps;
+    std::deque<BaseParams *> dump_accelerator_params;
+    // Last two args are dump tiling and hack tiling for the AHA flow
+    // TODO: The hack tiling needs to be refined. Only hack if the operation or layer is in the hack list
+    MapOperation(currentOperation, dump_accelerator_params, dump_accelerator_memory_maps, true, true);
 
     int runtime_scale_factor = 1;
     std::cout << "Operation: " << currentOperation.name << std::endl;
@@ -474,13 +480,18 @@ void Harness::sendParams() {
       bool matrixParamsValid, vectorParamsValid;
 
       BaseParams *baseParam = accelerator_params.front();
+      BaseParams *dumpBaseParam = dump_accelerator_params.front();
 
       MatrixParams *matrixParams = dynamic_cast<MatrixParams *>(baseParam);
+      MatrixParams *dumpMatrixParams = dynamic_cast<MatrixParams *>(dumpBaseParam);
       matrixParamsValid = matrixParams != NULL;
 
       if (matrixParamsValid) {
         accelerator_params.pop_front();
         baseParam = accelerator_params.front();
+        
+        dump_accelerator_params.pop_front();
+        dumpBaseParam = dump_accelerator_params.front();
       }
 
       VectorParams *vectorParams = dynamic_cast<VectorParams *>(baseParam);
@@ -510,43 +521,28 @@ void Harness::sendParams() {
         nlohmann::json tensor_metadata;
         tensor_metadata_file >> tensor_metadata;
 
-        auto& input_shape = tensor_metadata["ops"][0]["kwargs"]["input"]["tensor"]["shape"];
-        auto& weight_shape = tensor_metadata["ops"][0]["kwargs"]["weight"]["tensor"]["shape"];
-        auto& input_scale_shape = tensor_metadata["ops"][0]["kwargs"]["input_scale"]["tensor"]["shape"];
-        auto& weight_scale_shape = tensor_metadata["ops"][0]["kwargs"]["weight_scale"]["tensor"]["shape"];
-
-        int input_size = input_shape[0].get<int>() * input_shape[1].get<int>() * input_shape[2].get<int>() * input_shape[3].get<int>();
-        int weight_size = weight_shape[0].get<int>() * weight_shape[1].get<int>() * weight_shape[2].get<int>() * weight_shape[3].get<int>();
-        int input_scale_size = input_scale_shape[0].get<int>() * input_scale_shape[1].get<int>() * input_scale_shape[2].get<int>() * input_scale_shape[3].get<int>();
-        int weight_scale_size = weight_scale_shape[0].get<int>() * weight_scale_shape[1].get<int>() * weight_scale_shape[2].get<int>() * weight_scale_shape[3].get<int>();
-
-        // Must be 32B aligned b/c 32 is the OC unrolling. Word width in GLB is 32B.
-        double input_size_aligned = std::ceil(((double)input_size) / 32.0) * 32.0;
-        double input_scale_size_aligned = std::ceil(((double)input_scale_size) / 32.0) * 32.0;
-        double weight_size_aligned = std::ceil(((double)weight_size) / 32.0) * 32.0;
-        double weight_scale_size_aligned = std::ceil(((double)weight_scale_size) / 32.0) * 32.0;
-
-        // Print all the aligned sizes
-        std::cout << "Input size aligned: " << input_size_aligned << std::endl;
-        std::cout << "Input scale size aligned: " << input_scale_size_aligned << std::endl;
-        std::cout << "Weight size aligned: " << weight_size_aligned << std::endl;
-        std::cout << "Weight scale size aligned: " << weight_scale_size_aligned << std::endl;
-
         uint64_t glb_base_addr = tensor_metadata["mu_glb_base_address"].get<uint64_t>();
         printf("\nMU-GLB base address: %d\n", glb_base_addr);
-        uint64_t input_offset = glb_base_addr; // read the rest from model.txt using keyword args (OR could store in json file to read in)
-        uint64_t input_scale_offset = input_offset + (uint64_t)input_size_aligned;
-        uint64_t weight_offset = input_scale_offset + (uint64_t)input_scale_size_aligned;
-        uint64_t weight_scale_offset = weight_offset + (uint64_t)weight_size_aligned;
-        uint64_t bias_offset = weight_scale_offset + (uint64_t)weight_scale_size_aligned;
+        uint64_t input_offset = tensor_metadata["ops"][0]["kwargs"]["input"]["tensor"]["glb_base_address"];
+        uint64_t input_scale_offset = tensor_metadata["ops"][0]["kwargs"]["input_scale"]["tensor"]["glb_base_address"];
+        uint64_t weight_offset = tensor_metadata["ops"][0]["kwargs"]["weight"]["tensor"]["glb_base_address"];
+        uint64_t weight_scale_offset = tensor_metadata["ops"][0]["kwargs"]["weight_scale"]["tensor"]["glb_base_address"];
+        uint64_t bias_offset = tensor_metadata["ops"][0]["kwargs"]["bias"]["tensor"]["glb_base_address"];
 
-        matrixParams->INPUT_OFFSET = input_offset;
-        matrixParams->INPUT_SCALE_OFFSET = input_scale_offset;
-        matrixParams->WEIGHT_OFFSET = weight_offset;
-        matrixParams->WEIGHT_SCALE_OFFSET = weight_scale_offset;
-        matrixParams->BIAS_OFFSET = bias_offset;
+        // Print all the offsets
+        std::cout << "Input offset: " << input_offset << std::endl;
+        std::cout << "Input scale offset: " << input_scale_offset << std::endl;
+        std::cout << "Weight offset: " << weight_offset << std::endl;
+        std::cout << "Weight scale offset: " << weight_scale_offset << std::endl;
+        std::cout << "Bias offset: " << bias_offset << std::endl;
 
-        dumpSerializedParams<MatrixParams, 32>(*matrixParams);
+        dumpMatrixParams->INPUT_OFFSET = input_offset;
+        dumpMatrixParams->INPUT_SCALE_OFFSET = input_scale_offset;
+        dumpMatrixParams->WEIGHT_OFFSET = weight_offset;
+        dumpMatrixParams->WEIGHT_SCALE_OFFSET = weight_scale_offset;
+        dumpMatrixParams->BIAS_OFFSET = bias_offset;
+
+        dumpSerializedParams<MatrixParams, 32>(*dumpMatrixParams);
         matrixUnitStartSignal.SyncPop();
       }
 

--- a/test/common/Harness.cc
+++ b/test/common/Harness.cc
@@ -465,9 +465,13 @@ void Harness::sendParams() {
 
     std::deque<AcceleratorMemoryMap> dump_accelerator_memory_maps;
     std::deque<BaseParams *> dump_accelerator_params;
+
+
+    const char* kernel_and_stride_hack_env = std::getenv("KERNEL_AND_STRIDE_HACK");
+    bool dump_tiling = true;
+    bool hack_tiling = kernel_and_stride_hack_env && std::stoi(kernel_and_stride_hack_env) == 1;
     // Last two args are dump tiling and hack tiling for the AHA flow
-    // TODO: The hack tiling needs to be refined. Only hack if the operation or layer is in the hack list
-    MapOperation(currentOperation, dump_accelerator_params, dump_accelerator_memory_maps, true, true);
+    MapOperation(currentOperation, dump_accelerator_params, dump_accelerator_memory_maps, dump_tiling, hack_tiling);
 
     int runtime_scale_factor = 1;
     std::cout << "Operation: " << currentOperation.name << std::endl;
@@ -489,7 +493,7 @@ void Harness::sendParams() {
       if (matrixParamsValid) {
         accelerator_params.pop_front();
         baseParam = accelerator_params.front();
-        
+
         dump_accelerator_params.pop_front();
         dumpBaseParam = dump_accelerator_params.front();
       }

--- a/test/common/Harness.cc
+++ b/test/common/Harness.cc
@@ -5,10 +5,12 @@
 
 #include <cassert>
 #include <cstdint>  // for uint32_t
+#include <string>
 
 #include "AccelTypes.h"
 #include "sysc/kernel/sc_time.h"
 #include "lib/nlohmann/json.hpp"
+
 
 #ifndef CFLOAT
 #include "test/toolchain/MapOperation.h"
@@ -467,12 +469,12 @@ void Harness::sendParams() {
     std::deque<BaseParams *> dump_accelerator_params;
 
 
-    const char* kernel_and_stride_hack_env = std::getenv("KERNEL_AND_STRIDE_HACK");
+    const char* zircon_fx_fy_stride_workaround_env = std::getenv("ZIRCON_FX_FY_STRIDE_WORKAROUND");
     const char* zircon_cgra_psum_workaround_env = std::getenv("ZIRCON_CGRA_PSUM_WORKAROUND");
     bool dump_tiling = true;
-    bool kernel_and_stride_hack = kernel_and_stride_hack_env && std::stoi(kernel_and_stride_hack_env) == 1;
+    bool zircon_fx_fy_stride_workaround = zircon_fx_fy_stride_workaround_env && std::stoi(zircon_fx_fy_stride_workaround_env) == 1;
     bool zircon_cgra_psum_workaround = zircon_cgra_psum_workaround_env && std::stoi(zircon_cgra_psum_workaround_env) == 1;
-    bool hack_tiling = kernel_and_stride_hack || zircon_cgra_psum_workaround;
+    bool hack_tiling = zircon_fx_fy_stride_workaround || zircon_cgra_psum_workaround;
     // Last two args are dump tiling and hack tiling for the AHA flow
     MapOperation(currentOperation, dump_accelerator_params, dump_accelerator_memory_maps, dump_tiling, hack_tiling);
 
@@ -535,6 +537,43 @@ void Harness::sendParams() {
         uint64_t weight_offset = tensor_metadata["ops"][0]["kwargs"]["weight"]["tensor"]["glb_base_address"];
         uint64_t weight_scale_offset = tensor_metadata["ops"][0]["kwargs"]["weight_scale"]["tensor"]["glb_base_address"];
         uint64_t bias_offset = tensor_metadata["ops"][0]["kwargs"]["bias"]["tensor"]["glb_base_address"];
+
+        auto& input_shape = tensor_metadata["ops"][0]["kwargs"]["input"]["tensor"]["shape"];
+        auto& weight_shape = tensor_metadata["ops"][0]["kwargs"]["weight"]["tensor"]["shape"];
+        auto& input_scale_shape = tensor_metadata["ops"][0]["kwargs"]["input_scale"]["tensor"]["shape"];
+        auto& weight_scale_shape = tensor_metadata["ops"][0]["kwargs"]["weight_scale"]["tensor"]["shape"];
+
+        int input_size = input_shape[0].get<int>() * input_shape[1].get<int>() * input_shape[2].get<int>() * input_shape[3].get<int>();
+        int weight_size = weight_shape[0].get<int>() * weight_shape[1].get<int>() * weight_shape[2].get<int>() * weight_shape[3].get<int>();
+        int input_scale_size = input_scale_shape[0].get<int>() * input_scale_shape[1].get<int>() * input_scale_shape[2].get<int>() * input_scale_shape[3].get<int>();
+        int weight_scale_size = weight_scale_shape[0].get<int>() * weight_scale_shape[1].get<int>() * weight_scale_shape[2].get<int>() * weight_scale_shape[3].get<int>();
+
+        // Adjust the offsets if using zircon CGRA PSUM workaround: account for tiling along reduction dimension
+        if (zircon_cgra_psum_workaround) {
+          const char* num_psums_env = std::getenv("NUM_PSUMS");
+          const char* psum_idx_env = std::getenv("PSUM_IDX");
+
+          printf("NUM_PSUMS: %s\n", num_psums_env);
+          printf("PSUM_IDX: %s\n", psum_idx_env);
+
+          int num_psums;
+          int psum_idx;
+
+          if (num_psums_env && psum_idx_env) {
+            num_psums = std::stoi(num_psums_env);
+            psum_idx = std::stoi(psum_idx_env);
+          } else {
+            throw std::runtime_error(
+                "Zircon CGRA PSUM workaround requires NUM_PSUMS and PSUM_IDX "
+                "environment variables to be set.");
+          }
+
+          uint64_t input_offset_incr = psum_idx * (input_size / num_psums);
+          input_offset += input_offset_incr;
+          input_scale_offset += psum_idx * (input_scale_size/num_psums);
+          weight_offset += psum_idx * (weight_size/num_psums);
+          weight_scale_offset += psum_idx * (weight_scale_size/num_psums);
+        }
 
         // Print all the offsets
         std::cout << "Input offset: " << input_offset << std::endl;

--- a/test/common/Harness.cc
+++ b/test/common/Harness.cc
@@ -468,8 +468,11 @@ void Harness::sendParams() {
 
 
     const char* kernel_and_stride_hack_env = std::getenv("KERNEL_AND_STRIDE_HACK");
+    const char* zircon_cgra_psum_workaround_env = std::getenv("ZIRCON_CGRA_PSUM_WORKAROUND");
     bool dump_tiling = true;
-    bool hack_tiling = kernel_and_stride_hack_env && std::stoi(kernel_and_stride_hack_env) == 1;
+    bool kernel_and_stride_hack = kernel_and_stride_hack_env && std::stoi(kernel_and_stride_hack_env) == 1;
+    bool zircon_cgra_psum_workaround = zircon_cgra_psum_workaround_env && std::stoi(zircon_cgra_psum_workaround_env) == 1;
+    bool hack_tiling = kernel_and_stride_hack || zircon_cgra_psum_workaround;
     // Last two args are dump tiling and hack tiling for the AHA flow
     MapOperation(currentOperation, dump_accelerator_params, dump_accelerator_memory_maps, dump_tiling, hack_tiling);
 

--- a/test/common/Simulation.cc
+++ b/test/common/Simulation.cc
@@ -279,7 +279,7 @@ int Simulation::check_outputs() {
 
     std::string suffix = ".";
     if (outputs1.size() > 1) {
-      suffix = "_" + std::to_string(i);
+      suffix = "_" + std::to_string(i)  + ".";
     }
 
     if (tensor.dtype() == "bfloat16") {

--- a/test/common/Tiling.cc
+++ b/test/common/Tiling.cc
@@ -29,14 +29,19 @@ std::ostream& operator<<(std::ostream& os, const Tiling& tiling) {
   return os;
 }
 
-Tiling get_tiling(const Operation& operation) {
+Tiling get_tiling(const Operation& operation, bool hack_tiling) {
   const auto param = operation.param;
   const auto op_list = get_op_list(param);
   const auto first_op = op_list[0];
 
+  std::string operation_name = first_op.name();
+
   // get environment variable
   const char* env_var = std::getenv("MANUAL_TILING");
   bool manual_tiling = env_var ? std::stoi(env_var) : false;
+
+  const char* kernel_and_stride_hack_env = std::getenv("KERNEL_AND_STRIDE_HACK");
+  bool kernel_and_stride_hack = kernel_and_stride_hack_env && std::stoi(kernel_and_stride_hack_env) == 1;
 
   Tiling tiling;
   if (manual_tiling || !operation.has_valid_tiling) {
@@ -45,6 +50,8 @@ Tiling get_tiling(const Operation& operation) {
     } else {
       tiling = get_linear_tiling(first_op);
     }
+  } else if (kernel_and_stride_hack && hack_tiling) {
+        tiling = get_kernel_and_stride_hack_tiling(first_op);
   } else {
     tiling = get_interstellar_tiling(operation.tiling);
     if (first_op.kwargs().contains("stride")) {
@@ -53,6 +60,59 @@ Tiling get_tiling(const Operation& operation) {
     } else {
       tiling.stride = 1;
     }
+  }
+
+  return tiling;
+}
+
+
+Tiling get_kernel_and_stride_hack_tiling(const codegen::OpOverload param) {
+  Tiling tiling;
+
+  printf("Using kernel and stride hack for %s\n", param.name().c_str());
+  const auto kwargs = param.kwargs();
+  const auto input = kwargs.at("input").tensor();
+  const auto weight = kwargs.at("weight").tensor();
+  const auto strides = kwargs.at("stride").int_list().values();
+
+  const auto input_shape = get_shape(input);
+  const auto weight_shape = get_shape(weight);
+  int stride = strides[0];
+
+  // conv4 downsample
+  if (input_shape[1] == 128 && input_shape[2] == 28 && input_shape[3] == 28 &&
+      weight_shape[0] == 256 && weight_shape[2] == 1 && weight_shape[3] == 1 && stride == 2) {
+
+    tiling = {
+          .loops = {{1, 1, 8, 2, 1, 1}, {1, 1, 3, 3, 28, 28}},
+          .x_loop_index = {1, 5},
+          .y_loop_index = {0, 4},
+          .reduction_loop_index = {3, 0},
+          .weight_loop_index = {2, 1},
+          .fx_index = 3,
+          .fy_index = 2,
+          .weight_reuse_index = {4, 5},
+          .stride = 1,
+          .replication = false,
+      };
+  // conv5 downsample
+  } else if (input_shape[1] == 256 && input_shape[2] == 14 && input_shape[3] == 14 &&
+      weight_shape[0] == 512 && weight_shape[2] == 1 && weight_shape[3] == 1 && stride == 2) {
+
+        tiling = {
+          .loops = {{1, 1, 16, 4, 1, 1}, {1, 1, 3, 3, 14, 14}},
+          .x_loop_index = {1, 5},
+          .y_loop_index = {0, 4},
+          .reduction_loop_index = {3, 0},
+          .weight_loop_index = {2, 1},
+          .fx_index = 3,
+          .fy_index = 2,
+          .weight_reuse_index = {4, 5},
+          .stride = 1,
+          .replication = false,
+      };
+  } else {
+     throw std::runtime_error("Zircon kernel and stride hack not implemented for this layer!");
   }
 
   return tiling;

--- a/test/common/Tiling.cc
+++ b/test/common/Tiling.cc
@@ -43,6 +43,9 @@ Tiling get_tiling(const Operation& operation, bool hack_tiling) {
   const char* kernel_and_stride_hack_env = std::getenv("KERNEL_AND_STRIDE_HACK");
   bool kernel_and_stride_hack = kernel_and_stride_hack_env && std::stoi(kernel_and_stride_hack_env) == 1;
 
+  const char* zircon_cgra_psum_workaround_env = std::getenv("ZIRCON_CGRA_PSUM_WORKAROUND");
+  bool zircon_cgra_psum_workaround = zircon_cgra_psum_workaround_env && std::stoi(zircon_cgra_psum_workaround_env) == 1;
+
   Tiling tiling;
   if (manual_tiling || !operation.has_valid_tiling) {
     if (first_op.target() == "conv2d" || first_op.target() == "conv2d_mx") {
@@ -59,6 +62,12 @@ Tiling get_tiling(const Operation& operation, bool hack_tiling) {
       tiling.stride = stride[0];
     } else {
       tiling.stride = 1;
+    }
+
+    // PSUM workaround for Zircon. MU reduction loop bounds must be 1 for MU to work.
+    if (zircon_cgra_psum_workaround && hack_tiling) {
+      tiling.loops[0][tiling.reduction_loop_index[0]] = 1;
+      tiling.loops[1][tiling.reduction_loop_index[1]] = 1;
     }
   }
 

--- a/test/common/Tiling.cc
+++ b/test/common/Tiling.cc
@@ -40,8 +40,8 @@ Tiling get_tiling(const Operation& operation, bool hack_tiling) {
   const char* env_var = std::getenv("MANUAL_TILING");
   bool manual_tiling = env_var ? std::stoi(env_var) : false;
 
-  const char* kernel_and_stride_hack_env = std::getenv("KERNEL_AND_STRIDE_HACK");
-  bool kernel_and_stride_hack = kernel_and_stride_hack_env && std::stoi(kernel_and_stride_hack_env) == 1;
+  const char* zircon_fx_fy_stride_workaround_env = std::getenv("ZIRCON_FX_FY_STRIDE_WORKAROUND");
+  bool zircon_fx_fy_stride_workaround = zircon_fx_fy_stride_workaround_env && std::stoi(zircon_fx_fy_stride_workaround_env) == 1;
 
   const char* zircon_cgra_psum_workaround_env = std::getenv("ZIRCON_CGRA_PSUM_WORKAROUND");
   bool zircon_cgra_psum_workaround = zircon_cgra_psum_workaround_env && std::stoi(zircon_cgra_psum_workaround_env) == 1;
@@ -53,8 +53,8 @@ Tiling get_tiling(const Operation& operation, bool hack_tiling) {
     } else {
       tiling = get_linear_tiling(first_op);
     }
-  } else if (kernel_and_stride_hack && hack_tiling) {
-        tiling = get_kernel_and_stride_hack_tiling(first_op);
+  } else if (zircon_fx_fy_stride_workaround && hack_tiling) {
+        tiling = get_zircon_fx_fy_stride_workaround_tiling(first_op);
   } else {
     tiling = get_interstellar_tiling(operation.tiling);
     if (first_op.kwargs().contains("stride")) {
@@ -75,7 +75,7 @@ Tiling get_tiling(const Operation& operation, bool hack_tiling) {
 }
 
 
-Tiling get_kernel_and_stride_hack_tiling(const codegen::OpOverload param) {
+Tiling get_zircon_fx_fy_stride_workaround_tiling(const codegen::OpOverload param) {
   Tiling tiling;
 
   printf("Using kernel and stride hack for %s\n", param.name().c_str());
@@ -121,7 +121,7 @@ Tiling get_kernel_and_stride_hack_tiling(const codegen::OpOverload param) {
           .replication = false,
       };
   } else {
-     throw std::runtime_error("Zircon kernel and stride hack not implemented for this layer!");
+     throw std::runtime_error("Zircon fx, fy, stride workaround not implemented for this layer!");
   }
 
   return tiling;

--- a/test/common/Tiling.h
+++ b/test/common/Tiling.h
@@ -21,9 +21,10 @@ struct Tiling {
 
 std::ostream& operator<<(std::ostream& os, const Tiling& tiling);
 Tiling get_interstellar_tiling(const voyager::Tiling& tiling);
-Tiling get_tiling(const Operation& operation);
+Tiling get_tiling(const Operation& operation, bool hack_tiling);
 
 Tiling get_conv2d_tiling(const codegen::OpOverload param);
 Tiling get_linear_tiling(const codegen::OpOverload param);
 Tiling get_pool2d_tiling(const codegen::OpOverload param);
+Tiling get_kernel_and_stride_hack_tiling(const codegen::OpOverload param);
 void adjust_tiling_for_dimension(Tiling& tiling);

--- a/test/common/Tiling.h
+++ b/test/common/Tiling.h
@@ -26,5 +26,5 @@ Tiling get_tiling(const Operation& operation, bool hack_tiling);
 Tiling get_conv2d_tiling(const codegen::OpOverload param);
 Tiling get_linear_tiling(const codegen::OpOverload param);
 Tiling get_pool2d_tiling(const codegen::OpOverload param);
-Tiling get_kernel_and_stride_hack_tiling(const codegen::OpOverload param);
+Tiling get_zircon_fx_fy_stride_workaround_tiling(const codegen::OpOverload param);
 void adjust_tiling_for_dimension(Tiling& tiling);

--- a/test/common/operations/MatrixOps.h
+++ b/test/common/operations/MatrixOps.h
@@ -322,7 +322,8 @@ template <typename Input, typename Psum, typename Buffer, typename Scale>
 inline Buffer *gemm(std::any input_ptr, std::any input_scale_ptr,
                     std::any weight_ptr, std::any weight_scale_ptr,
                     std::any bias_ptr, const Operation &operation) {
-  Tiling tiling = get_tiling(operation);
+  bool hack_tiling = false;
+  Tiling tiling = get_tiling(operation, hack_tiling);
 
   std::ostringstream oss;
   oss << "GEMM Tiling: " << tiling << std::endl;

--- a/test/toolchain/MapOperation.cc
+++ b/test/toolchain/MapOperation.cc
@@ -13,7 +13,7 @@
 
 void MapOperation(const Operation &operation,
                   std::deque<BaseParams *> &mappedParams,
-                  std::deque<AcceleratorMemoryMap> &opMemoryMaps) {
+                  std::deque<AcceleratorMemoryMap> &opMemoryMaps, bool dump_tiling, bool hack_tiling) {
   const auto param = operation.param;
   const auto op_list = get_op_list(param);
   const auto first_op = op_list[0];
@@ -29,7 +29,7 @@ void MapOperation(const Operation &operation,
     if (dim == 1) {
       MapMatrixVectorMultiply(param, mappedParams, opMemoryMaps);
     } else {
-      MapMatrixOperation(operation, mappedParams, opMemoryMaps);
+      MapMatrixOperation(operation, mappedParams, opMemoryMaps, dump_tiling, hack_tiling);
     }
   } else if (first_op.target() == "layer_norm") {
     MapLayerNorm(param, mappedParams, opMemoryMaps);

--- a/test/toolchain/MapOperation.h
+++ b/test/toolchain/MapOperation.h
@@ -6,4 +6,4 @@
 
 void MapOperation(const Operation &operation,
                   std::deque<BaseParams *> &mappedParams,
-                  std::deque<AcceleratorMemoryMap> &opMemoryMaps);
+                  std::deque<AcceleratorMemoryMap> &opMemoryMaps, bool dump_tiling, bool hack_tiling);

--- a/test/toolchain/MatrixOps.h
+++ b/test/toolchain/MatrixOps.h
@@ -135,25 +135,7 @@ void MapMatrixOperation(const Operation &operation,
   const auto op_list = get_op_list(param);
   const auto matrix_op = op_list[0];
 
-  Tiling tiling = get_tiling(operation);
-
-  // TEMPORARY HACK
-  if (hack_tiling) {
-      // Temporary hack to use reduction loop of 1 for downsample layers for testing
-    tiling = {
-          .loops = {{1, 8, 2, 1, 1, 1}, {1, 1, 1, 1, 7, 14}},
-          .x_loop_index = {0, 5},
-          .y_loop_index = {2, 4},
-          .reduction_loop_index = {3, 0},
-          .weight_loop_index = {1, 1},
-          .fx_index = 3,
-          .fy_index = 2,
-          .weight_reuse_index = {4, 5},
-          .stride = 2,
-          .replication = false,
-      };
-  }
-// TEMPORARY HACK
+  Tiling tiling = get_tiling(operation, hack_tiling);
 
   // --------------DATA DUMPING FOR AHA FLOW-------------------//
   if (dump_tiling) {

--- a/test/toolchain/MatrixOps.h
+++ b/test/toolchain/MatrixOps.h
@@ -127,7 +127,7 @@ void set_immediate(const float scalar, const int stage,
 
 void MapMatrixOperation(const Operation &operation,
                         std::deque<BaseParams *> &mappedParams,
-                        std::deque<AcceleratorMemoryMap> &opMemoryMaps) {
+                        std::deque<AcceleratorMemoryMap> &opMemoryMaps, bool dump_tiling, bool hack_tiling) {
   MatrixParams *matrix_params = new MatrixParams;
   AcceleratorMemoryMap accelerator_memory_map;
 
@@ -136,6 +136,38 @@ void MapMatrixOperation(const Operation &operation,
   const auto matrix_op = op_list[0];
 
   Tiling tiling = get_tiling(operation);
+
+  // TEMPORARY HACK
+  if (hack_tiling) {
+      // Temporary hack to use reduction loop of 1 for downsample layers for testing
+    tiling = {
+          .loops = {{1, 8, 2, 1, 1, 1}, {1, 1, 1, 1, 7, 14}},
+          .x_loop_index = {0, 5},
+          .y_loop_index = {2, 4},
+          .reduction_loop_index = {3, 0},
+          .weight_loop_index = {1, 1},
+          .fx_index = 3,
+          .fy_index = 2,
+          .weight_reuse_index = {4, 5},
+          .stride = 2,
+          .replication = false,
+      };
+  }
+// TEMPORARY HACK
+
+  // --------------DATA DUMPING FOR AHA FLOW-------------------//
+  if (dump_tiling) {
+    std::ofstream output_tiling_dump_file;
+    // Delete the file if it exists
+    std::remove("output_tiling.txt");
+    output_tiling_dump_file.open("output_tiling.txt", std::ios::app);
+    if (!output_tiling_dump_file.is_open()) {
+      spdlog::error("Failed to open output_tiling.txt for writing.");
+      return;
+    }
+    output_tiling_dump_file << tiling;
+  }
+  // --------------DATA DUMPING FOR AHA FLOW-------------------//
 
   int X = tiling.loops[0][tiling.x_loop_index[0]] *
           tiling.loops[1][tiling.x_loop_index[1]];
@@ -149,17 +181,6 @@ void MapMatrixOperation(const Operation &operation,
   int FY = tiling.loops[1][tiling.fy_index];
   int STRIDE = tiling.stride;
 
-  // Dumping for AHA flow
-  std::ofstream output_tiling_dump_file;
-  // Delete the file if it exists
-  std::remove("output_tiling.txt");
-  output_tiling_dump_file.open("output_tiling.txt", std::ios::app);
-  if (!output_tiling_dump_file.is_open()) {
-    spdlog::error("Failed to open output_tiling.txt for writing.");
-    return;
-  }
-
-  output_tiling_dump_file << tiling;
   std::ostringstream oss;
   oss << tiling;
   spdlog::info("Using tiling: \n{}\n", oss.str());


### PR DESCRIPTION
This PR does the following:

1) Introduces workarounds for conv4_x and conv5_x downsample layers
2) Adds mechanism for comparing output of systolic array between RTL and systemC
3) Dumps systolic array partial sums to text file
4) Unifies tensor address mapping previously duplicated in `harness.cc` and `parse_dnnLayer_tensors.py` into a single function in `run_regression.py`
5) Other code improvements 

Corresponding AHA PR: https://github.com/StanfordAHA/aha/pull/2064