### PR TITLE
Zircon conv5 host tiling & bug workaround

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,6 +317,8 @@ create-env: .conda-env
 .conda-env:
 	@echo "Creating voyager conda environment..."
 	@bash -c '\
+	    conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main; \
+		conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r; \
 		conda env create -p .conda-env -f environment.yml; \
 		conda init && eval "$$(conda shell.bash hook)"; \
 		conda activate ./.conda-env; \

--- a/run_regression.py
+++ b/run_regression.py
@@ -744,23 +744,36 @@ def add_layers(network, layers, layer_counts, uniquify):
 
 def append_glb_base_addresses(kwargs, mu_glb_base_address):
     zircon_fx_fy_stride_workaround = "ZIRCON_FX_FY_STRIDE_WORKAROUND" in os.environ and os.environ["ZIRCON_FX_FY_STRIDE_WORKAROUND"] == "1"
+    zircon_double_ox_oy_workaround = "ZIRCON_DOUBLE_OX_OY_WORKAROUND" in os.environ and os.environ["ZIRCON_DOUBLE_OX_OY_WORKAROUND"] == "1"
+    k_dim_host_tiling = "K_DIM_HOST_TILING" in os.environ and os.environ["K_DIM_HOST_TILING"] == "1"
+    if k_dim_host_tiling:
+        num_k_host_tiling_kernels = int(os.environ.get("NUM_K_HOST_TILING_KERNELS", 1))
+        k_dim_host_tiling_idx = int(os.environ.get("K_DIM_HOST_TILING_INDEX", 0))
 
     # Append GLB base addresses to the kwargs for input, weight, bias, inputScale, and weightScale tensors
     input_base_address = mu_glb_base_address
 
     # multiply all element in kwargs['input']['tensor']['shape'] together and add to input_base_address
     input_num_elements = functools.reduce(operator.mul, kwargs['input']['tensor']['shape'], 1)
+    if zircon_double_ox_oy_workaround:
+        input_num_elements *= 2 * 2
     inputScale_base_address = input_base_address + math.ceil(input_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
 
     inputScale_num_elements = functools.reduce(operator.mul, kwargs['input_scale']['tensor']['shape'], 1)
+    if zircon_double_ox_oy_workaround:
+        inputScale_num_elements *= 2 * 2
     weight_base_address = inputScale_base_address + math.ceil(inputScale_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
 
     weight_num_elements = functools.reduce(operator.mul, kwargs['weight']['tensor']['shape'], 1)
+    if k_dim_host_tiling:
+        weight_num_elements = weight_num_elements // num_k_host_tiling_kernels
     if zircon_fx_fy_stride_workaround:
         weight_num_elements *= 3 * 3
     weightScale_base_address = weight_base_address + math.ceil(weight_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
 
     weightScale_num_elements = functools.reduce(operator.mul, kwargs['weight_scale']['tensor']['shape'], 1)
+    if k_dim_host_tiling:
+        weightScale_num_elements = weightScale_num_elements // num_k_host_tiling_kernels
     if zircon_fx_fy_stride_workaround:
         weightScale_num_elements *= 3 * 3
 

--- a/run_regression.py
+++ b/run_regression.py
@@ -744,24 +744,29 @@ def add_layers(network, layers, layer_counts, uniquify):
 
 def append_glb_base_addresses(kwargs, mu_glb_base_address):
     zircon_fx_fy_stride_workaround = "ZIRCON_FX_FY_STRIDE_WORKAROUND" in os.environ and os.environ["ZIRCON_FX_FY_STRIDE_WORKAROUND"] == "1"
-    zircon_double_ox_oy_workaround = "ZIRCON_DOUBLE_OX_OY_WORKAROUND" in os.environ and os.environ["ZIRCON_DOUBLE_OX_OY_WORKAROUND"] == "1"
+    zircon_input_padding_workaround = "ZIRCON_INPUT_PADDING_WORKAROUND" in os.environ and os.environ["ZIRCON_INPUT_PADDING_WORKAROUND"] == "1"
+    if zircon_input_padding_workaround:
+        assert "ZIRCON_INPUT_PADDING_WORKAROUND_SIZE" in os.environ, "ZIRCON_INPUT_PADDING_WORKAROUND_SIZE environment variable must be set for ZIRCON_INPUT_PADDING_WORKAROUND"
+        zircon_input_padding_workaround_size = int(os.environ.get("ZIRCON_INPUT_PADDING_WORKAROUND_SIZE", 0))
     k_dim_host_tiling = "K_DIM_HOST_TILING" in os.environ and os.environ["K_DIM_HOST_TILING"] == "1"
     if k_dim_host_tiling:
+        assert "NUM_K_HOST_TILING_KERNELS" in os.environ, "NUM_K_HOST_TILING_KERNELS environment variable must be set for K_DIM_HOST_TILING"
         num_k_host_tiling_kernels = int(os.environ.get("NUM_K_HOST_TILING_KERNELS", 1))
-        k_dim_host_tiling_idx = int(os.environ.get("K_DIM_HOST_TILING_INDEX", 0))
 
     # Append GLB base addresses to the kwargs for input, weight, bias, inputScale, and weightScale tensors
     input_base_address = mu_glb_base_address
 
     # multiply all element in kwargs['input']['tensor']['shape'] together and add to input_base_address
     input_num_elements = functools.reduce(operator.mul, kwargs['input']['tensor']['shape'], 1)
-    if zircon_double_ox_oy_workaround:
-        input_num_elements *= 2 * 2
+    if zircon_input_padding_workaround:
+        input_shape = kwargs['input']['tensor']['shape']
+        input_num_elements = input_shape[0] * input_shape[1] * (input_shape[2] + zircon_input_padding_workaround_size) * (input_shape[3] + zircon_input_padding_workaround_size)
     inputScale_base_address = input_base_address + math.ceil(input_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
 
     inputScale_num_elements = functools.reduce(operator.mul, kwargs['input_scale']['tensor']['shape'], 1)
-    if zircon_double_ox_oy_workaround:
-        inputScale_num_elements *= 2 * 2
+    if zircon_input_padding_workaround:
+        inputScale_shape = kwargs['input_scale']['tensor']['shape']
+        inputScale_num_elements = inputScale_shape[0] * inputScale_shape[1] * (inputScale_shape[2] + zircon_input_padding_workaround_size) * (inputScale_shape[3] + zircon_input_padding_workaround_size)
     weight_base_address = inputScale_base_address + math.ceil(inputScale_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
 
     weight_num_elements = functools.reduce(operator.mul, kwargs['weight']['tensor']['shape'], 1)

--- a/run_regression.py
+++ b/run_regression.py
@@ -744,10 +744,10 @@ def add_layers(network, layers, layer_counts, uniquify):
 
 def append_glb_base_addresses(kwargs, mu_glb_base_address):
     zircon_fx_fy_stride_workaround = "ZIRCON_FX_FY_STRIDE_WORKAROUND" in os.environ and os.environ["ZIRCON_FX_FY_STRIDE_WORKAROUND"] == "1"
-    zircon_input_padding_workaround = "ZIRCON_INPUT_PADDING_WORKAROUND" in os.environ and os.environ["ZIRCON_INPUT_PADDING_WORKAROUND"] == "1"
-    if zircon_input_padding_workaround:
-        assert "ZIRCON_INPUT_PADDING_WORKAROUND_SIZE" in os.environ, "ZIRCON_INPUT_PADDING_WORKAROUND_SIZE environment variable must be set for ZIRCON_INPUT_PADDING_WORKAROUND"
-        zircon_input_padding_workaround_size = int(os.environ.get("ZIRCON_INPUT_PADDING_WORKAROUND_SIZE", 0))
+    zircon_input_act_padding_workaround = "ZIRCON_INPUT_ACT_PADDING_WORKAROUND" in os.environ and os.environ["ZIRCON_INPUT_ACT_PADDING_WORKAROUND"] == "1"
+    if zircon_input_act_padding_workaround:
+        assert "ZIRCON_INPUT_ACT_PADDING_WORKAROUND_SIZE" in os.environ, "ZIRCON_INPUT_ACT_PADDING_WORKAROUND_SIZE environment variable must be set for ZIRCON_INPUT_ACT_PADDING_WORKAROUND"
+        zircon_input_act_padding_workaround_size = int(os.environ.get("ZIRCON_INPUT_ACT_PADDING_WORKAROUND_SIZE", 0))
     k_dim_host_tiling = "K_DIM_HOST_TILING" in os.environ and os.environ["K_DIM_HOST_TILING"] == "1"
     if k_dim_host_tiling:
         assert "NUM_K_HOST_TILING_KERNELS" in os.environ, "NUM_K_HOST_TILING_KERNELS environment variable must be set for K_DIM_HOST_TILING"
@@ -758,15 +758,15 @@ def append_glb_base_addresses(kwargs, mu_glb_base_address):
 
     # multiply all element in kwargs['input']['tensor']['shape'] together and add to input_base_address
     input_num_elements = functools.reduce(operator.mul, kwargs['input']['tensor']['shape'], 1)
-    if zircon_input_padding_workaround:
+    if zircon_input_act_padding_workaround:
         input_shape = kwargs['input']['tensor']['shape']
-        input_num_elements = input_shape[0] * input_shape[1] * (input_shape[2] + zircon_input_padding_workaround_size) * (input_shape[3] + zircon_input_padding_workaround_size)
+        input_num_elements = input_shape[0] * input_shape[1] * (input_shape[2] + zircon_input_act_padding_workaround_size) * (input_shape[3] + zircon_input_act_padding_workaround_size)
     inputScale_base_address = input_base_address + math.ceil(input_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
 
     inputScale_num_elements = functools.reduce(operator.mul, kwargs['input_scale']['tensor']['shape'], 1)
-    if zircon_input_padding_workaround:
+    if zircon_input_act_padding_workaround:
         inputScale_shape = kwargs['input_scale']['tensor']['shape']
-        inputScale_num_elements = inputScale_shape[0] * inputScale_shape[1] * (inputScale_shape[2] + zircon_input_padding_workaround_size) * (inputScale_shape[3] + zircon_input_padding_workaround_size)
+        inputScale_num_elements = inputScale_shape[0] * inputScale_shape[1] * (inputScale_shape[2] + zircon_input_act_padding_workaround_size) * (inputScale_shape[3] + zircon_input_act_padding_workaround_size)
     weight_base_address = inputScale_base_address + math.ceil(inputScale_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
 
     weight_num_elements = functools.reduce(operator.mul, kwargs['weight']['tensor']['shape'], 1)

--- a/scripts/aha_flow/adjust_gold_for_k_tiling.py
+++ b/scripts/aha_flow/adjust_gold_for_k_tiling.py
@@ -1,0 +1,60 @@
+import argparse
+import os
+import re
+
+def adjust_gold_for_k_tiling(input_file, output_file, channel_size, total_num_kernels, kernel_idx):
+    with open(input_file, "r") as f:
+        lines = [line.strip() for line in f]
+
+    result = []
+    micro_kernel_size = channel_size // total_num_kernels
+
+    # Safety check
+    if channel_size % total_num_kernels != 0:
+        raise ValueError("channel_size must be divisible by total_num_kernels")
+
+    for i, val in enumerate(lines):
+        # Position within current channel_size group
+        group_pos = i % channel_size
+
+        # Which micro-kernel is this line in?
+        micro_kernel_idx = group_pos // micro_kernel_size
+
+        # Keep only the desired kernel, zero out others
+        if micro_kernel_idx == kernel_idx:
+            result.append(val)
+        else:
+            result.append("0000")
+
+    with open(output_file, "w") as f:
+        f.write("\n".join(result))
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Zero out all micro-kernels except the selected one.")
+
+    parser.add_argument("--input", required=True, help="Path to input file")
+    parser.add_argument("--output", required=True, help="Path to output file")
+
+    args = parser.parse_args()
+
+    k_dim_host_tiling = "K_DIM_HOST_TILING" in os.environ and os.environ["K_DIM_HOST_TILING"] == "1"
+    # Do nothing if K_DIM_HOST_TILING is not set
+    if k_dim_host_tiling:
+        assert "NUM_K_HOST_TILING_KERNELS" in os.environ, "NUM_K_HOST_TILING_KERNELS environment variable must be set for K_DIM_HOST_TILING"
+        assert "K_DIM_HOST_TILING_IDX" in os.environ, "K_DIM_HOST_TILING_IDX environment variable must be set for K_DIM_HOST_TILING"
+        num_k_host_tiling_kernels = int(os.environ["NUM_K_HOST_TILING_KERNELS"])
+        k_host_tiling_idx = int(os.environ["K_DIM_HOST_TILING_IDX"])
+
+        assert "HALIDE_GEN_ARGS" in os.environ, "HALIDE_GEN_ARGS environment variable must be set for K_DIM_HOST_TILING"
+        HALIDE_GEN_ARGS = os.environ["HALIDE_GEN_ARGS"]
+        n_oc_match = re.search(r'n_oc=(\d+)', HALIDE_GEN_ARGS)
+        assert n_oc_match, "No n_oc in HALIDE_GEN_ARGS!"
+        n_oc = int(n_oc_match.group(1))
+
+        adjust_gold_for_k_tiling(
+            args.input,
+            args.output,
+            n_oc,
+            num_k_host_tiling_kernels,
+            k_host_tiling_idx
+        )

--- a/scripts/aha_flow/glb_dma_config.py
+++ b/scripts/aha_flow/glb_dma_config.py
@@ -127,7 +127,7 @@ def get_glb_dma_config_helper(loop_order, loop_bounds):
     return dimensionality, trimmed_strides, trimmed_extents
 
 
-def get_glb_dma_config(output_tiling_filepath: str, zircon_fx_fy_stride_workaround: bool = False, zircon_input_padding_workaround: bool = False):
+def get_glb_dma_config(output_tiling_filepath: str, zircon_fx_fy_stride_workaround: bool = False, zircon_input_act_padding_workaround: bool = False):
     """
     Reads the tiling file and returns the GLB DMA config.
     The tiling file should contain the loop order and loop bounds in a specific format.
@@ -156,12 +156,12 @@ def get_glb_dma_config(output_tiling_filepath: str, zircon_fx_fy_stride_workarou
             loop_bounds[0] = loop_bounds[0] // 2 # divide X0 by 2 to account for the hack; actual output is 2x smaller than what MU produces
             loop_bounds[1] = loop_bounds[1] // 2 # divide Y0 by 2 to account for the hack; actual output is 2x smaller than what MU produces
 
-        if zircon_input_padding_workaround:
-            assert "ZIRCON_INPUT_PADDING_WORKAROUND_SIZE" in os.environ, "ZIRCON_INPUT_PADDING_WORKAROUND_SIZE environment variable must be set for ZIRCON_INPUT_PADDING_WORKAROUND"
-            zircon_input_padding_workaround_size = int(os.environ.get("ZIRCON_INPUT_PADDING_WORKAROUND_SIZE", 0))
+        if zircon_input_act_padding_workaround:
+            assert "ZIRCON_INPUT_ACT_PADDING_WORKAROUND_SIZE" in os.environ, "ZIRCON_INPUT_ACT_PADDING_WORKAROUND_SIZE environment variable must be set for ZIRCON_INPUT_ACT_PADDING_WORKAROUND"
+            zircon_input_act_padding_workaround_size = int(os.environ.get("ZIRCON_INPUT_ACT_PADDING_WORKAROUND_SIZE", 0))
             # This file needs to ignore the padding to produce the correct addresses to store REAL data in GLB (i.e. the padded output gets filtered)
-            loop_bounds[0] = loop_bounds[0] - zircon_input_padding_workaround_size
-            loop_bounds[1] = loop_bounds[1] - zircon_input_padding_workaround_size
+            loop_bounds[0] = loop_bounds[0] - zircon_input_act_padding_workaround_size
+            loop_bounds[1] = loop_bounds[1] - zircon_input_act_padding_workaround_size
 
         # Construct loop order based on the indices
         # Map variable names to their values
@@ -178,8 +178,7 @@ def get_glb_dma_config(output_tiling_filepath: str, zircon_fx_fy_stride_workarou
     return get_glb_dma_config_helper(loop_order, loop_bounds)
 
 if __name__ == "__main__":
-    # dimensionality, strides, extents = get_glb_dma_config("/aha/voyager/compiled_collateral/resnet18-conv2d_mx_default_11/output_tiling.txt")
-    dimensionality, strides, extents = get_glb_dma_config("./output_tiling.txt")
+    dimensionality, strides, extents = get_glb_dma_config("/aha/voyager/compiled_collateral/resnet18-conv2d_mx_default_11/output_tiling.txt")
     print(f"Dimensionality: {dimensionality}")
     print(f"Strides: {strides}")
     print(f"Extents: {extents}")

--- a/scripts/aha_flow/glb_dma_config.py
+++ b/scripts/aha_flow/glb_dma_config.py
@@ -42,7 +42,7 @@ def print_addr_map(X0, Y0, X1, Y1, K1, K2):
                     for y0 in range(0, Y0):
                         for x0 in range(0, X0):
                             addr = get_address(x0, y0, x1, y1, k1, k2, X0, Y0, X1, Y1, K1, K2)
-                            print(f"addr: {addr}, bank index: {int(addr/32)}, y1: {y1}, x1: {x1}, k1: {k1}, y0: {y0}, x0: {x0}")
+                            print(f"addr: {addr}, bank index: {int(addr/32)}, y1: {y1}, x1: {x1}, k2: {k2}, k1: {k1}, y0: {y0}, x0: {x0}")
 
 
 def get_dimensionality(X0, Y0, X1, Y1, K1, K2):
@@ -79,6 +79,14 @@ def compute_strides(loop_order, loop_bounds, arg_indices_dict):
 
     # The addresss function is defined as: addr = y * (X1 * X0 * K2 * K1 * K0) + x * (K2 * K1 * K0) + k
     """
+
+    # FIXME: Temporary HACK
+    k_dim_host_tiling = "K_DIM_HOST_TILING" in os.environ and os.environ["K_DIM_HOST_TILING"] == "1"
+    if k_dim_host_tiling:
+        num_k_host_tiling_kernels = int(os.environ.get("NUM_K_HOST_TILING_KERNELS", 1))
+        # UNDO the change made in the tiling file. i.e. in Tiling.cc. Need to formalize this
+        loop_bounds[5] = loop_bounds[5] * num_k_host_tiling_kernels
+
     strides = [0] * len(loop_order)
     for idx, loop in enumerate(loop_order):
         addr_args_1 = [0] * len(arg_indices_dict)
@@ -98,11 +106,18 @@ def compute_strides(loop_order, loop_bounds, arg_indices_dict):
         # the stride is +8 in the GLB bank address space, which translates to +32 in the MU address space.
         strides[idx] = (addr_1 - addr_0) // 32
 
+
+     # FIXME: very hacky
+    if k_dim_host_tiling:
+        loop_bounds[5] = loop_bounds[5] // num_k_host_tiling_kernels # Restore the original K2 value
+
     return strides
 
 
 
 def get_glb_dma_config_helper(loop_order, loop_bounds):
+
+    print_addr_map(*loop_bounds)
     strides = compute_strides(loop_order, loop_bounds, arg_indices_dict)
 
     trimmed_strides, trimmed_extents = trim_dimensionality(strides, loop_bounds, loop_order, arg_indices_dict)
@@ -144,6 +159,13 @@ def get_glb_dma_config(output_tiling_filepath: str, zircon_fx_fy_stride_workarou
             loop_bounds[0] = loop_bounds[0] // 2 # divide X0 by 2 to account for the hack; actual output is 2x smaller than what MU produces
             loop_bounds[1] = loop_bounds[1] // 2 # divide Y0 by 2 to account for the hack; actual output is 2x smaller than what MU produces
 
+        # FIXME: Temporary HACK
+        # FOR K_DIM HOST TILING, DO THE SAME AS THE ABOVE
+        zircon_double_ox_oy_workaround = "ZIRCON_DOUBLE_OX_OY_WORKAROUND" in os.environ and os.environ["ZIRCON_DOUBLE_OX_OY_WORKAROUND"] == "1"
+        if zircon_double_ox_oy_workaround:
+            loop_bounds[0] = loop_bounds[0] // 2 # divide X0 by 2 to account for the hack; actual output is 2x smaller than what MU produces
+            loop_bounds[1] = loop_bounds[1] // 2 # divide Y0 by 2 to account for the hack; actual output is 2x smaller than what MU produces
+
         # Construct loop order based on the indices
         # Map variable names to their values
         outer_vars_dict = {"X1": x_loop_indices[0], "Y1": y_loop_indices[0], "K2": k_loop_indices[0]}
@@ -159,7 +181,8 @@ def get_glb_dma_config(output_tiling_filepath: str, zircon_fx_fy_stride_workarou
     return get_glb_dma_config_helper(loop_order, loop_bounds)
 
 if __name__ == "__main__":
-    dimensionality, strides, extents = get_glb_dma_config("/aha/voyager/compiled_collateral/resnet18-conv2d_mx_default_11/output_tiling.txt")
+    # dimensionality, strides, extents = get_glb_dma_config("/aha/voyager/compiled_collateral/resnet18-conv2d_mx_default_11/output_tiling.txt")
+    dimensionality, strides, extents = get_glb_dma_config("./output_tiling.txt")
     print(f"Dimensionality: {dimensionality}")
     print(f"Strides: {strides}")
     print(f"Extents: {extents}")

--- a/scripts/aha_flow/glb_dma_config.py
+++ b/scripts/aha_flow/glb_dma_config.py
@@ -80,11 +80,13 @@ def compute_strides(loop_order, loop_bounds, arg_indices_dict):
     # The addresss function is defined as: addr = y * (X1 * X0 * K2 * K1 * K0) + x * (K2 * K1 * K0) + k
     """
 
-    # FIXME: Temporary HACK
     k_dim_host_tiling = "K_DIM_HOST_TILING" in os.environ and os.environ["K_DIM_HOST_TILING"] == "1"
     if k_dim_host_tiling:
-        num_k_host_tiling_kernels = int(os.environ.get("NUM_K_HOST_TILING_KERNELS", 1))
-        # UNDO the change made in the tiling file. i.e. in Tiling.cc. Need to formalize this
+        assert "NUM_K_HOST_TILING_KERNELS" in os.environ, "NUM_K_HOST_TILING_KERNELS environment variable must be set for K_DIM_HOST_TILING"
+        num_k_host_tiling_kernels = int(os.environ.get("NUM_K_HOST_TILING_KERNELS"))
+        # UNDO the change made in the tiling file. i.e. in Tiling.cc.
+        # This is because the tiling file is generated with the assumption that K2 is divided by the number of host tiling kernels, but we need to restore the original K2 value for the stride calculation
+        # to ensure data is stored in correct GLB addresses across all host tiling kernels.
         loop_bounds[5] = loop_bounds[5] * num_k_host_tiling_kernels
 
     strides = [0] * len(loop_order)
@@ -106,10 +108,8 @@ def compute_strides(loop_order, loop_bounds, arg_indices_dict):
         # the stride is +8 in the GLB bank address space, which translates to +32 in the MU address space.
         strides[idx] = (addr_1 - addr_0) // 32
 
-
-     # FIXME: very hacky
     if k_dim_host_tiling:
-        loop_bounds[5] = loop_bounds[5] // num_k_host_tiling_kernels # Restore the original K2 value
+        loop_bounds[5] = loop_bounds[5] // num_k_host_tiling_kernels # Restore K2 value
 
     return strides
 
@@ -117,7 +117,6 @@ def compute_strides(loop_order, loop_bounds, arg_indices_dict):
 
 def get_glb_dma_config_helper(loop_order, loop_bounds):
 
-    print_addr_map(*loop_bounds)
     strides = compute_strides(loop_order, loop_bounds, arg_indices_dict)
 
     trimmed_strides, trimmed_extents = trim_dimensionality(strides, loop_bounds, loop_order, arg_indices_dict)
@@ -130,7 +129,7 @@ def get_glb_dma_config_helper(loop_order, loop_bounds):
     return dimensionality, trimmed_strides, trimmed_extents
 
 
-def get_glb_dma_config(output_tiling_filepath: str, zircon_fx_fy_stride_workaround: bool = False):
+def get_glb_dma_config(output_tiling_filepath: str, zircon_fx_fy_stride_workaround: bool = False, zircon_input_padding_workaround: bool = False):
     """
     Reads the tiling file and returns the GLB DMA config.
     The tiling file should contain the loop order and loop bounds in a specific format.
@@ -159,12 +158,12 @@ def get_glb_dma_config(output_tiling_filepath: str, zircon_fx_fy_stride_workarou
             loop_bounds[0] = loop_bounds[0] // 2 # divide X0 by 2 to account for the hack; actual output is 2x smaller than what MU produces
             loop_bounds[1] = loop_bounds[1] // 2 # divide Y0 by 2 to account for the hack; actual output is 2x smaller than what MU produces
 
-        # FIXME: Temporary HACK
-        # FOR K_DIM HOST TILING, DO THE SAME AS THE ABOVE
-        zircon_double_ox_oy_workaround = "ZIRCON_DOUBLE_OX_OY_WORKAROUND" in os.environ and os.environ["ZIRCON_DOUBLE_OX_OY_WORKAROUND"] == "1"
-        if zircon_double_ox_oy_workaround:
-            loop_bounds[0] = loop_bounds[0] // 2 # divide X0 by 2 to account for the hack; actual output is 2x smaller than what MU produces
-            loop_bounds[1] = loop_bounds[1] // 2 # divide Y0 by 2 to account for the hack; actual output is 2x smaller than what MU produces
+        if zircon_input_padding_workaround:
+            assert "ZIRCON_INPUT_PADDING_WORKAROUND_SIZE" in os.environ, "ZIRCON_INPUT_PADDING_WORKAROUND_SIZE environment variable must be set for ZIRCON_INPUT_PADDING_WORKAROUND"
+            zircon_input_padding_workaround_size = int(os.environ.get("ZIRCON_INPUT_PADDING_WORKAROUND_SIZE", 0))
+            # This file needs to ignore the padding to produce the correct addresses to store REAL data in GLB (i.e. the padded output gets filtered)
+            loop_bounds[0] = loop_bounds[0] - zircon_input_padding_workaround_size
+            loop_bounds[1] = loop_bounds[1] - zircon_input_padding_workaround_size
 
         # Construct loop order based on the indices
         # Map variable names to their values

--- a/scripts/aha_flow/glb_dma_config.py
+++ b/scripts/aha_flow/glb_dma_config.py
@@ -124,8 +124,6 @@ def get_glb_dma_config_helper(loop_order, loop_bounds):
     assert len(trimmed_strides) == dimensionality
     assert len(trimmed_extents) == dimensionality
 
-    # Adjust innermost extent to account for aha flow (*= 4, so full data is loaded into GLB. Extent that is programmed in HW (in map.c) will again be divided by 4)
-    trimmed_extents[0] *= 4
     return dimensionality, trimmed_strides, trimmed_extents
 
 

--- a/scripts/aha_flow/parse_dnnLayer_tensors.py
+++ b/scripts/aha_flow/parse_dnnLayer_tensors.py
@@ -130,11 +130,11 @@ def parse_zircon_workarounds():
         num_psums = int(os.environ["NUM_PSUMS"])
 
     # Input padding workaround for Zircon MU inability to handle some layer shapes
-    zircon_input_padding_workaround = "ZIRCON_INPUT_PADDING_WORKAROUND" in os.environ and os.environ["ZIRCON_INPUT_PADDING_WORKAROUND"] == "1"
-    zircon_input_padding_workaround_size = 0
-    if zircon_input_padding_workaround:
-        assert "ZIRCON_INPUT_PADDING_WORKAROUND_SIZE" in os.environ, "ZIRCON_INPUT_PADDING_WORKAROUND_SIZE environment variable must be set for ZIRCON_INPUT_PADDING_WORKAROUND"
-        zircon_input_padding_workaround_size = int(os.environ.get("ZIRCON_INPUT_PADDING_WORKAROUND_SIZE"))
+    zircon_input_act_padding_workaround = "ZIRCON_INPUT_ACT_PADDING_WORKAROUND" in os.environ and os.environ["ZIRCON_INPUT_ACT_PADDING_WORKAROUND"] == "1"
+    zircon_input_act_padding_workaround_size = 0
+    if zircon_input_act_padding_workaround:
+        assert "ZIRCON_INPUT_ACT_PADDING_WORKAROUND_SIZE" in os.environ, "ZIRCON_INPUT_ACT_PADDING_WORKAROUND_SIZE environment variable must be set for ZIRCON_INPUT_ACT_PADDING_WORKAROUND"
+        zircon_input_act_padding_workaround_size = int(os.environ.get("ZIRCON_INPUT_ACT_PADDING_WORKAROUND_SIZE"))
 
     # K dimension host tiling: used in resnet18 conv5 in Zircon
     k_dim_host_tiling = "K_DIM_HOST_TILING" in os.environ and os.environ["K_DIM_HOST_TILING"] == "1"
@@ -152,15 +152,15 @@ def parse_zircon_workarounds():
     if zircon_fx_fy_stride_workaround:
         print("\033[93mINFO: Zircon FX, FY stride workaround enabled to avoid MU bug on downsample layers.\033[0m")
 
-    if zircon_input_padding_workaround:
-        print(f"\033[93mINFO: Zircon input padding workaround enabled. Input image will be padded with +{zircon_input_padding_workaround_size}.\033[0m")
+    if zircon_input_act_padding_workaround:
+        print(f"\033[93mINFO: Zircon input padding workaround enabled. Input image will be padded with +{zircon_input_act_padding_workaround_size}.\033[0m")
 
     if k_dim_host_tiling:
         print(f"\033[93mINFO: K dimension host tiling enabled. Using {num_k_host_tiling_kernels} kernels with index {k_dim_host_tiling_idx}.\033[0m")
 
 
     return zircon_fx_fy_stride_workaround, zircon_cgra_psum_workaround, psum_idx, num_psums, \
-           zircon_input_padding_workaround, zircon_input_padding_workaround_size, \
+           zircon_input_act_padding_workaround, zircon_input_act_padding_workaround_size, \
            k_dim_host_tiling, num_k_host_tiling_kernels, k_dim_host_tiling_idx
 
 
@@ -198,15 +198,15 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
 
 
     zircon_fx_fy_stride_workaround, zircon_cgra_psum_workaround, psum_idx, num_psums, \
-    zircon_input_padding_workaround, zircon_input_padding_workaround_size, \
+    zircon_input_act_padding_workaround, zircon_input_act_padding_workaround_size, \
     k_dim_host_tiling, num_k_host_tiling_kernels, k_dim_host_tiling_idx = parse_zircon_workarounds()
 
     # INPUT
     # Shape is in format: (OC, IC, Y, X)
     input = read_tensor(base_path + input_tensor_data["node"] + ".bin",
                         (input_tensor_data["shape"][0], input_tensor_data["shape"][1], input_tensor_data["shape"][2], input_tensor_data["shape"][3]))
-    if zircon_input_padding_workaround:
-        input = F.pad(input, pad=(0, zircon_input_padding_workaround_size, 0, zircon_input_padding_workaround_size)) # Pad X and Y dimensions with zeros
+    if zircon_input_act_padding_workaround:
+        input = F.pad(input, pad=(0, zircon_input_act_padding_workaround_size, 0, zircon_input_act_padding_workaround_size)) # Pad X and Y dimensions with zeros
     # Re-order it so IC is the innermost dimension (Y, X, OC, IC)
     input_reordered = input.permute(2, 3, 0, 1)
     if zircon_cgra_psum_workaround:
@@ -219,8 +219,8 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
     # Shape is in format: (OC, IC / BLOCK_SIZE, Y, X)
     inputScale = read_tensor(base_path + inputScale_tensor_data["node"] + ".bin",
                              (inputScale_tensor_data["shape"][0], inputScale_tensor_data["shape"][1], inputScale_tensor_data["shape"][2], inputScale_tensor_data["shape"][3]))
-    if zircon_input_padding_workaround:
-        inputScale = F.pad(inputScale, pad=(0, zircon_input_padding_workaround_size, 0, zircon_input_padding_workaround_size)) # Pad X and Y dimensions with zeros
+    if zircon_input_act_padding_workaround:
+        inputScale = F.pad(inputScale, pad=(0, zircon_input_act_padding_workaround_size, 0, zircon_input_act_padding_workaround_size)) # Pad X and Y dimensions with zeros
     # Re-order it so IC is the innermost dimension (Y, X, OC, IC / BLOCK_SIZE)
     inputScale_reordered = inputScale.permute(2, 3, 0, 1)
     if zircon_cgra_psum_workaround:
@@ -287,8 +287,8 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
             residual_tmp[:, :, 1::2, 1::2] = residual
             residual = residual_tmp
 
-        if zircon_input_padding_workaround:
-            residual = F.pad(residual, pad=(0, zircon_input_padding_workaround_size, 0, zircon_input_padding_workaround_size), value=-1000) # Pad with -1000 instead of 0s to catch potential bugs 
+        if zircon_input_act_padding_workaround:
+            residual = F.pad(residual, pad=(0, zircon_input_act_padding_workaround_size, 0, zircon_input_act_padding_workaround_size), value=-1000) # Pad with -1000 instead of 0s to catch potential bugs
 
         # Re-order it so IC is the innermost dimension (Y, X, OC, IC)
         residual_reordered = residual.permute(2, 3, 0, 1)

--- a/scripts/aha_flow/parse_dnnLayer_tensors.py
+++ b/scripts/aha_flow/parse_dnnLayer_tensors.py
@@ -287,8 +287,15 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
             residual_tmp[:, :, 1::2, 1::2] = residual
             residual = residual_tmp
 
+        if zircon_input_padding_workaround:
+            residual = F.pad(residual, pad=(0, zircon_input_padding_workaround_size, 0, zircon_input_padding_workaround_size), value=-1000) # Pad with -1000 instead of 0s to catch potential bugs 
+
         # Re-order it so IC is the innermost dimension (Y, X, OC, IC)
         residual_reordered = residual.permute(2, 3, 0, 1)
+        if k_dim_host_tiling:
+            residual_reordered = residual_reordered.reshape((residual.shape[2], residual.shape[3], residual.shape[0], num_k_host_tiling_kernels, residual.shape[1] // num_k_host_tiling_kernels))
+            residual_reordered = residual_reordered.permute(3, 0, 1, 2, 4)
+            residual_reordered = residual_reordered[k_dim_host_tiling_idx]
         residual_bf16 = float32_to_bfloat16_bits(residual_reordered)
         residual_bf16_be = residual_bf16.byteswap().newbyteorder('>')
 

--- a/scripts/aha_flow/parse_dnnLayer_tensors.py
+++ b/scripts/aha_flow/parse_dnnLayer_tensors.py
@@ -117,6 +117,53 @@ def hw_output_txt_to_raw(input_txt_path, output_raw_path):
     uint16_array_be.tofile(output_raw_path)
 
 
+def parse_zircon_workarounds():
+    # Workarounds to avoid Zircon MU bug on Resnet downsample layers
+    zircon_fx_fy_stride_workaround = "ZIRCON_FX_FY_STRIDE_WORKAROUND" in os.environ and os.environ["ZIRCON_FX_FY_STRIDE_WORKAROUND"] == "1"
+    zircon_cgra_psum_workaround = "ZIRCON_CGRA_PSUM_WORKAROUND" in os.environ and os.environ["ZIRCON_CGRA_PSUM_WORKAROUND"] == "1"
+    psum_idx = 0
+    num_psums = 1
+    if zircon_cgra_psum_workaround:
+        assert "PSUM_IDX" in os.environ, "PSUM_IDX environment variable must be set for ZIRCON_CGRA_PSUM_WORKAROUND"
+        assert "NUM_PSUMS" in os.environ, "NUM_PSUMS environment variable must be set for ZIRCON_CGRA_PSUM_WORKAROUND"
+        psum_idx = int(os.environ["PSUM_IDX"])
+        num_psums = int(os.environ["NUM_PSUMS"])
+
+    # Input padding workaround for Zircon MU inability to handle some layer shapes
+    zircon_input_padding_workaround = "ZIRCON_INPUT_PADDING_WORKAROUND" in os.environ and os.environ["ZIRCON_INPUT_PADDING_WORKAROUND"] == "1"
+    zircon_input_padding_workaround_size = 0
+    if zircon_input_padding_workaround:
+        assert "ZIRCON_INPUT_PADDING_WORKAROUND_SIZE" in os.environ, "ZIRCON_INPUT_PADDING_WORKAROUND_SIZE environment variable must be set for ZIRCON_INPUT_PADDING_WORKAROUND"
+        zircon_input_padding_workaround_size = int(os.environ.get("ZIRCON_INPUT_PADDING_WORKAROUND_SIZE"))
+
+    # K dimension host tiling: used in resnet18 conv5 in Zircon
+    k_dim_host_tiling = "K_DIM_HOST_TILING" in os.environ and os.environ["K_DIM_HOST_TILING"] == "1"
+    num_k_host_tiling_kernels = 1
+    k_dim_host_tiling_idx = 0
+    if k_dim_host_tiling:
+        assert "NUM_K_HOST_TILING_KERNELS" in os.environ, "NUM_K_HOST_TILING_KERNELS environment variable must be set for K_DIM_HOST_TILING"
+        assert "K_DIM_HOST_TILING_IDX" in os.environ, "K_DIM_HOST_TILING_IDX environment variable must be set for K_DIM_HOST_TILING"
+        num_k_host_tiling_kernels = int(os.environ.get("NUM_K_HOST_TILING_KERNELS"))
+        k_dim_host_tiling_idx = int(os.environ.get("K_DIM_HOST_TILING_IDX"))
+
+    if zircon_cgra_psum_workaround:
+        print(f"\033[93mINFO: Zircon CGRA PSUM workaround enabled to avoid MU bug on downsample layers. Using PSUM index {psum_idx}. There are {num_psums} total PSUMs.\033[0m")
+
+    if zircon_fx_fy_stride_workaround:
+        print("\033[93mINFO: Zircon FX, FY stride workaround enabled to avoid MU bug on downsample layers.\033[0m")
+
+    if zircon_input_padding_workaround:
+        print(f"\033[93mINFO: Zircon input padding workaround enabled. Input image will be padded with +{zircon_input_padding_workaround_size}.\033[0m")
+
+    if k_dim_host_tiling:
+        print(f"\033[93mINFO: K dimension host tiling enabled. Using {num_k_host_tiling_kernels} kernels with index {k_dim_host_tiling_idx}.\033[0m")
+
+
+    return zircon_fx_fy_stride_workaround, zircon_cgra_psum_workaround, psum_idx, num_psums, \
+           zircon_input_padding_workaround, zircon_input_padding_workaround_size, \
+           k_dim_host_tiling, num_k_host_tiling_kernels, k_dim_host_tiling_idx
+
+
 def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
     # Base path for the binary files
     base_path = f'/aha/voyager/test/compiler/networks/{model}/{datatype}/tensor_files/'
@@ -149,36 +196,17 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
 
     mu_glb_base_addr = tensor_metadata["mu_glb_base_address"]
 
-    # Workarounds to avoid Zircon MU bug on Resnet downsample layers
-    zircon_fx_fy_stride_workaround = "ZIRCON_FX_FY_STRIDE_WORKAROUND" in os.environ and os.environ["ZIRCON_FX_FY_STRIDE_WORKAROUND"] == "1"
-    zircon_cgra_psum_workaround = "ZIRCON_CGRA_PSUM_WORKAROUND" in os.environ and os.environ["ZIRCON_CGRA_PSUM_WORKAROUND"] == "1"
-    psum_idx = "PSUM_IDX" in os.environ and int(os.environ["PSUM_IDX"]) if zircon_cgra_psum_workaround else 1
-    num_psums = "NUM_PSUMS" in os.environ and int(os.environ["NUM_PSUMS"]) if zircon_cgra_psum_workaround else 1
-    zircon_double_ox_oy_workaround = "ZIRCON_DOUBLE_OX_OY_WORKAROUND" in os.environ and os.environ["ZIRCON_DOUBLE_OX_OY_WORKAROUND"] == "1"
 
-
-    if zircon_cgra_psum_workaround:
-        print(f"\033[93mINFO: Zircon CGRA PSUM workaround enabled to avoid MU bug on downsample layers. Using PSUM index {psum_idx}. There are {num_psums} total PSUMs.\033[0m")
-
-    if zircon_fx_fy_stride_workaround:
-        print("\033[93mINFO: Zircon FX, FY stride workaround enabled to avoid MU bug on downsample layers.\033[0m")
-
-
-    # K dimension host tiling
-    k_dim_host_tiling = "K_DIM_HOST_TILING" in os.environ and os.environ["K_DIM_HOST_TILING"] == "1"
-    if k_dim_host_tiling:
-        num_k_host_tiling_kernels = int(os.environ.get("NUM_K_HOST_TILING_KERNELS", 1))
-        k_dim_host_tiling_idx = int(os.environ.get("K_DIM_HOST_TILING_INDEX", 0))
-
-    if k_dim_host_tiling:
-        print(f"\033[93mINFO: K dimension host tiling enabled. Using {num_k_host_tiling_kernels} kernels with index {k_dim_host_tiling_idx}.\033[0m")
+    zircon_fx_fy_stride_workaround, zircon_cgra_psum_workaround, psum_idx, num_psums, \
+    zircon_input_padding_workaround, zircon_input_padding_workaround_size, \
+    k_dim_host_tiling, num_k_host_tiling_kernels, k_dim_host_tiling_idx = parse_zircon_workarounds()
 
     # INPUT
     # Shape is in format: (OC, IC, Y, X)
     input = read_tensor(base_path + input_tensor_data["node"] + ".bin",
                         (input_tensor_data["shape"][0], input_tensor_data["shape"][1], input_tensor_data["shape"][2], input_tensor_data["shape"][3]))
-    if zircon_double_ox_oy_workaround:
-        input = F.pad(input, pad=(0, input_tensor_data["shape"][2], 0, input_tensor_data["shape"][3])) # Double the input size in X and Y dimensions and pad with zeros
+    if zircon_input_padding_workaround:
+        input = F.pad(input, pad=(0, zircon_input_padding_workaround_size, 0, zircon_input_padding_workaround_size)) # Pad X and Y dimensions with zeros
     # Re-order it so IC is the innermost dimension (Y, X, OC, IC)
     input_reordered = input.permute(2, 3, 0, 1)
     if zircon_cgra_psum_workaround:
@@ -191,8 +219,8 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
     # Shape is in format: (OC, IC / BLOCK_SIZE, Y, X)
     inputScale = read_tensor(base_path + inputScale_tensor_data["node"] + ".bin",
                              (inputScale_tensor_data["shape"][0], inputScale_tensor_data["shape"][1], inputScale_tensor_data["shape"][2], inputScale_tensor_data["shape"][3]))
-    if zircon_double_ox_oy_workaround:
-        inputScale = F.pad(inputScale, pad=(0, inputScale_tensor_data["shape"][2], 0, inputScale_tensor_data["shape"][3])) # Double the input size in X and Y dimensions and pad with zeros
+    if zircon_input_padding_workaround:
+        inputScale = F.pad(inputScale, pad=(0, zircon_input_padding_workaround_size, 0, zircon_input_padding_workaround_size)) # Pad X and Y dimensions with zeros
     # Re-order it so IC is the innermost dimension (Y, X, OC, IC / BLOCK_SIZE)
     inputScale_reordered = inputScale.permute(2, 3, 0, 1)
     if zircon_cgra_psum_workaround:

--- a/scripts/aha_flow/parse_dnnLayer_tensors.py
+++ b/scripts/aha_flow/parse_dnnLayer_tensors.py
@@ -154,6 +154,8 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
     zircon_cgra_psum_workaround = "ZIRCON_CGRA_PSUM_WORKAROUND" in os.environ and os.environ["ZIRCON_CGRA_PSUM_WORKAROUND"] == "1"
     psum_idx = "PSUM_IDX" in os.environ and int(os.environ["PSUM_IDX"]) if zircon_cgra_psum_workaround else 1
     num_psums = "NUM_PSUMS" in os.environ and int(os.environ["NUM_PSUMS"]) if zircon_cgra_psum_workaround else 1
+    zircon_double_ox_oy_workaround = "ZIRCON_DOUBLE_OX_OY_WORKAROUND" in os.environ and os.environ["ZIRCON_DOUBLE_OX_OY_WORKAROUND"] == "1"
+
 
     if zircon_cgra_psum_workaround:
         print(f"\033[93mINFO: Zircon CGRA PSUM workaround enabled to avoid MU bug on downsample layers. Using PSUM index {psum_idx}. There are {num_psums} total PSUMs.\033[0m")
@@ -161,10 +163,22 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
     if zircon_fx_fy_stride_workaround:
         print("\033[93mINFO: Zircon FX, FY stride workaround enabled to avoid MU bug on downsample layers.\033[0m")
 
+
+    # K dimension host tiling
+    k_dim_host_tiling = "K_DIM_HOST_TILING" in os.environ and os.environ["K_DIM_HOST_TILING"] == "1"
+    if k_dim_host_tiling:
+        num_k_host_tiling_kernels = int(os.environ.get("NUM_K_HOST_TILING_KERNELS", 1))
+        k_dim_host_tiling_idx = int(os.environ.get("K_DIM_HOST_TILING_INDEX", 0))
+
+    if k_dim_host_tiling:
+        print(f"\033[93mINFO: K dimension host tiling enabled. Using {num_k_host_tiling_kernels} kernels with index {k_dim_host_tiling_idx}.\033[0m")
+
     # INPUT
     # Shape is in format: (OC, IC, Y, X)
     input = read_tensor(base_path + input_tensor_data["node"] + ".bin",
                         (input_tensor_data["shape"][0], input_tensor_data["shape"][1], input_tensor_data["shape"][2], input_tensor_data["shape"][3]))
+    if zircon_double_ox_oy_workaround:
+        input = F.pad(input, pad=(0, input_tensor_data["shape"][2], 0, input_tensor_data["shape"][3])) # Double the input size in X and Y dimensions and pad with zeros
     # Re-order it so IC is the innermost dimension (Y, X, OC, IC)
     input_reordered = input.permute(2, 3, 0, 1)
     if zircon_cgra_psum_workaround:
@@ -177,6 +191,8 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
     # Shape is in format: (OC, IC / BLOCK_SIZE, Y, X)
     inputScale = read_tensor(base_path + inputScale_tensor_data["node"] + ".bin",
                              (inputScale_tensor_data["shape"][0], inputScale_tensor_data["shape"][1], inputScale_tensor_data["shape"][2], inputScale_tensor_data["shape"][3]))
+    if zircon_double_ox_oy_workaround:
+        inputScale = F.pad(inputScale, pad=(0, inputScale_tensor_data["shape"][2], 0, inputScale_tensor_data["shape"][3])) # Double the input size in X and Y dimensions and pad with zeros
     # Re-order it so IC is the innermost dimension (Y, X, OC, IC / BLOCK_SIZE)
     inputScale_reordered = inputScale.permute(2, 3, 0, 1)
     if zircon_cgra_psum_workaround:
@@ -195,7 +211,10 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
     if zircon_cgra_psum_workaround:
         weight_reordered = weight_reordered.reshape((weight_tensor_data["shape"][2], weight_tensor_data["shape"][3], weight_tensor_data["shape"][1] // 64, 64, weight_tensor_data["shape"][0]))
         weight_reordered = weight_reordered.permute(2, 0, 1, 3, 4)
-        # weight_reordered = weight_reordered[psum_idx]
+    if k_dim_host_tiling:
+        weight_reordered = weight_reordered.reshape((weight_tensor_data["shape"][2], weight_tensor_data["shape"][3], weight_tensor_data["shape"][1], num_k_host_tiling_kernels, weight_tensor_data["shape"][0] // num_k_host_tiling_kernels))
+        weight_reordered = weight_reordered.permute(3, 0, 1, 2, 4)
+        weight_reordered = weight_reordered[k_dim_host_tiling_idx]
     weight_int8 = weight_reordered.to(torch.int8)
     weight_start_addr = weight_tensor_data["glb_base_address"]
 
@@ -209,6 +228,10 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
     weightScale_reordered = weightScale.permute(2, 3, 1, 0)
     if zircon_cgra_psum_workaround:
         weightScale_reordered = weightScale_reordered.permute(2, 0, 1, 3)
+    if k_dim_host_tiling:
+        weightScale_reordered = weightScale_reordered.reshape((weightScale_tensor_data["shape"][2], weightScale_tensor_data["shape"][3], weightScale_tensor_data["shape"][1], num_k_host_tiling_kernels, weightScale_tensor_data["shape"][0] // num_k_host_tiling_kernels))
+        weightScale_reordered = weightScale_reordered.permute(3, 0, 1, 2, 4)
+        weightScale_reordered = weightScale_reordered[k_dim_host_tiling_idx]
     weightScale_e8m0 = float_to_e8m0(weightScale_reordered)
     weightScale_start_addr = weightScale_tensor_data["glb_base_address"]
 
@@ -217,6 +240,9 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
     if zircon_cgra_psum_workaround and psum_idx != 0:
         # If doing psum workaround, bias is zero for all but the 0th kernel
         bias = torch.zeros((bias_tensor_data["shape"][0],), dtype=torch.float32)
+    if k_dim_host_tiling:
+        bias = bias.reshape((num_k_host_tiling_kernels, bias_tensor_data["shape"][0] // num_k_host_tiling_kernels))
+        bias = bias[k_dim_host_tiling_idx]
     bias_bf16 = float32_to_bfloat16_bits(bias)
     bias_start_addr = bias_tensor_data["glb_base_address"]
 

--- a/test/common/Harness.cc
+++ b/test/common/Harness.cc
@@ -471,10 +471,12 @@ void Harness::sendParams() {
 
     const char* zircon_fx_fy_stride_workaround_env = std::getenv("ZIRCON_FX_FY_STRIDE_WORKAROUND");
     const char* zircon_cgra_psum_workaround_env = std::getenv("ZIRCON_CGRA_PSUM_WORKAROUND");
+    const char* k_dim_host_tiling_env = std::getenv("K_DIM_HOST_TILING");
     bool dump_tiling = true;
     bool zircon_fx_fy_stride_workaround = zircon_fx_fy_stride_workaround_env && std::stoi(zircon_fx_fy_stride_workaround_env) == 1;
     bool zircon_cgra_psum_workaround = zircon_cgra_psum_workaround_env && std::stoi(zircon_cgra_psum_workaround_env) == 1;
-    bool hack_tiling = zircon_fx_fy_stride_workaround || zircon_cgra_psum_workaround;
+    bool k_dim_host_tiling = k_dim_host_tiling_env && std::stoi(k_dim_host_tiling_env) == 1;
+    bool hack_tiling = zircon_fx_fy_stride_workaround || zircon_cgra_psum_workaround || k_dim_host_tiling;
     // Last two args are dump tiling and hack tiling for the AHA flow
     MapOperation(currentOperation, dump_accelerator_params, dump_accelerator_memory_maps, dump_tiling, hack_tiling);
 

--- a/test/common/Harness.cc
+++ b/test/common/Harness.cc
@@ -472,13 +472,13 @@ void Harness::sendParams() {
     const char* zircon_fx_fy_stride_workaround_env = std::getenv("ZIRCON_FX_FY_STRIDE_WORKAROUND");
     const char* zircon_cgra_psum_workaround_env = std::getenv("ZIRCON_CGRA_PSUM_WORKAROUND");
     const char* k_dim_host_tiling_env = std::getenv("K_DIM_HOST_TILING");
-    const char* zircon_input_padding_workaround_env = std::getenv("ZIRCON_INPUT_PADDING_WORKAROUND");
+    const char* zircon_input_act_padding_workaround_env = std::getenv("ZIRCON_INPUT_ACT_PADDING_WORKAROUND");
     bool dump_tiling = true;
     bool zircon_fx_fy_stride_workaround = zircon_fx_fy_stride_workaround_env && std::stoi(zircon_fx_fy_stride_workaround_env) == 1;
     bool zircon_cgra_psum_workaround = zircon_cgra_psum_workaround_env && std::stoi(zircon_cgra_psum_workaround_env) == 1;
     bool k_dim_host_tiling = k_dim_host_tiling_env && std::stoi(k_dim_host_tiling_env) == 1;
-    bool zircon_input_padding_workaround = zircon_input_padding_workaround_env && std::stoi(zircon_input_padding_workaround_env) == 1;
-    bool hack_tiling = zircon_fx_fy_stride_workaround || zircon_cgra_psum_workaround || k_dim_host_tiling || zircon_input_padding_workaround;
+    bool zircon_input_act_padding_workaround = zircon_input_act_padding_workaround_env && std::stoi(zircon_input_act_padding_workaround_env) == 1;
+    bool hack_tiling = zircon_fx_fy_stride_workaround || zircon_cgra_psum_workaround || k_dim_host_tiling || zircon_input_act_padding_workaround;
     // Last two args are dump tiling and hack tiling for the AHA flow
     MapOperation(currentOperation, dump_accelerator_params, dump_accelerator_memory_maps, dump_tiling, hack_tiling);
 

--- a/test/common/Harness.cc
+++ b/test/common/Harness.cc
@@ -472,11 +472,13 @@ void Harness::sendParams() {
     const char* zircon_fx_fy_stride_workaround_env = std::getenv("ZIRCON_FX_FY_STRIDE_WORKAROUND");
     const char* zircon_cgra_psum_workaround_env = std::getenv("ZIRCON_CGRA_PSUM_WORKAROUND");
     const char* k_dim_host_tiling_env = std::getenv("K_DIM_HOST_TILING");
+    const char* zircon_input_padding_workaround_env = std::getenv("ZIRCON_INPUT_PADDING_WORKAROUND");
     bool dump_tiling = true;
     bool zircon_fx_fy_stride_workaround = zircon_fx_fy_stride_workaround_env && std::stoi(zircon_fx_fy_stride_workaround_env) == 1;
     bool zircon_cgra_psum_workaround = zircon_cgra_psum_workaround_env && std::stoi(zircon_cgra_psum_workaround_env) == 1;
     bool k_dim_host_tiling = k_dim_host_tiling_env && std::stoi(k_dim_host_tiling_env) == 1;
-    bool hack_tiling = zircon_fx_fy_stride_workaround || zircon_cgra_psum_workaround || k_dim_host_tiling;
+    bool zircon_input_padding_workaround = zircon_input_padding_workaround_env && std::stoi(zircon_input_padding_workaround_env) == 1;
+    bool hack_tiling = zircon_fx_fy_stride_workaround || zircon_cgra_psum_workaround || k_dim_host_tiling || zircon_input_padding_workaround;
     // Last two args are dump tiling and hack tiling for the AHA flow
     MapOperation(currentOperation, dump_accelerator_params, dump_accelerator_memory_maps, dump_tiling, hack_tiling);
 

--- a/test/common/Tiling.cc
+++ b/test/common/Tiling.cc
@@ -46,6 +46,9 @@ Tiling get_tiling(const Operation& operation, bool hack_tiling) {
   const char* zircon_cgra_psum_workaround_env = std::getenv("ZIRCON_CGRA_PSUM_WORKAROUND");
   bool zircon_cgra_psum_workaround = zircon_cgra_psum_workaround_env && std::stoi(zircon_cgra_psum_workaround_env) == 1;
 
+  const char* k_dim_host_tiling_env = std::getenv("K_DIM_HOST_TILING");
+  bool k_dim_host_tiling = k_dim_host_tiling_env && std::stoi(k_dim_host_tiling_env) == 1;
+
   Tiling tiling;
   if (manual_tiling || !operation.has_valid_tiling) {
     if (first_op.target() == "conv2d" || first_op.target() == "conv2d_mx") {
@@ -69,6 +72,27 @@ Tiling get_tiling(const Operation& operation, bool hack_tiling) {
       tiling.loops[0][tiling.reduction_loop_index[0]] = 1;
       tiling.loops[1][tiling.reduction_loop_index[1]] = 1;
     }
+
+    // FIXME: TEMPORARY FOR NOW. This is a hack to get the k dimension tiling. Assuming can tile the K2 loop
+    if (k_dim_host_tiling && hack_tiling) {
+        const char* num_k_host_tiling_kernels_env = std::getenv("NUM_K_HOST_TILING_KERNELS");
+
+        printf("NUM_K_HOST_TILING_KERNELS: %s\n", num_k_host_tiling_kernels_env);
+
+        int num_k_host_tiling_kernels;
+
+        if (num_k_host_tiling_kernels_env) {
+          num_k_host_tiling_kernels = std::stoi(num_k_host_tiling_kernels_env);
+        } else {
+          throw std::runtime_error(
+              "Zircon K HOST TILING workaround requires NUM_K_HOST_TILING_KERNELS "
+              "environment variable to be set.");
+        }
+
+      // FIXME: Assuming this is divisble. Need to generalize this.
+      tiling.loops[0][tiling.weight_loop_index[0]] = tiling.loops[0][tiling.weight_loop_index[0]] / num_k_host_tiling_kernels;
+    }
+
   }
 
   return tiling;

--- a/test/common/Tiling.cc
+++ b/test/common/Tiling.cc
@@ -49,6 +49,9 @@ Tiling get_tiling(const Operation& operation, bool hack_tiling) {
   const char* k_dim_host_tiling_env = std::getenv("K_DIM_HOST_TILING");
   bool k_dim_host_tiling = k_dim_host_tiling_env && std::stoi(k_dim_host_tiling_env) == 1;
 
+  const char* zircon_input_padding_workaround_env = std::getenv("ZIRCON_INPUT_PADDING_WORKAROUND");
+  bool zircon_input_padding_workaround = zircon_input_padding_workaround_env && std::stoi(zircon_input_padding_workaround_env) == 1;
+
   Tiling tiling;
   if (manual_tiling || !operation.has_valid_tiling) {
     if (first_op.target() == "conv2d" || first_op.target() == "conv2d_mx") {
@@ -73,7 +76,6 @@ Tiling get_tiling(const Operation& operation, bool hack_tiling) {
       tiling.loops[1][tiling.reduction_loop_index[1]] = 1;
     }
 
-    // FIXME: TEMPORARY FOR NOW. This is a hack to get the k dimension tiling. Assuming can tile the K2 loop
     if (k_dim_host_tiling && hack_tiling) {
         const char* num_k_host_tiling_kernels_env = std::getenv("NUM_K_HOST_TILING_KERNELS");
 
@@ -89,10 +91,40 @@ Tiling get_tiling(const Operation& operation, bool hack_tiling) {
               "environment variable to be set.");
         }
 
-      // FIXME: Assuming this is divisble. Need to generalize this.
+      // NOTE: Assumption is that entire K loop is in k2 and it is divisible by num_k_host_tiling_kernels, which is the case for conv5 layers in Resnet18 on Zircon
+      if ((tiling.loops[0][tiling.weight_loop_index[0]] % num_k_host_tiling_kernels != 0) || (tiling.loops[1][tiling.weight_loop_index[1]] != 1)) {
+        throw std::runtime_error(
+            "Zircon K HOST TILING workaround by default assumes weight loop to be divisible by NUM_K_HOST_TILING_KERNELS and the second weight loop to be 1."
+            "Code modifications will be necessary to proceed.");
+      }
+
       tiling.loops[0][tiling.weight_loop_index[0]] = tiling.loops[0][tiling.weight_loop_index[0]] / num_k_host_tiling_kernels;
     }
 
+    // Workaround to pad inputs to account for Zircon MU's inability to handle some layer shapes
+    if (zircon_input_padding_workaround && hack_tiling){
+      const char* zircon_input_padding_workaround_size_env = std::getenv("ZIRCON_INPUT_PADDING_WORKAROUND_SIZE");
+      int zircon_input_padding_workaround_size;
+
+      if (zircon_input_padding_workaround_size_env) {
+        zircon_input_padding_workaround_size = std::stoi(zircon_input_padding_workaround_size_env);
+      } else {
+        throw std::runtime_error(
+            "Zircon input padding workaround requires ZIRCON_INPUT_PADDING_WORKAROUND_SIZE "
+            "environment variable to be set.");
+      }
+
+      // NOTE: Assumption is that the entire input image is in the inner loop, which is the case for conv5 layers in Resnet18 on Zircon
+      if ((tiling.loops[0][tiling.x_loop_index[0]] != 1) || (tiling.loops[0][tiling.y_loop_index[0]] != 1)) {
+        throw std::runtime_error(
+            "Zircon input padding workaround by default assumes outer x and y loops to be 1. "
+            "Code modifications will be necessary to proceed.");
+      }
+
+      tiling.loops[1][tiling.x_loop_index[1]] += zircon_input_padding_workaround_size;
+      tiling.loops[1][tiling.y_loop_index[1]] += zircon_input_padding_workaround_size;
+
+    }
   }
 
   return tiling;

--- a/test/common/Tiling.cc
+++ b/test/common/Tiling.cc
@@ -49,8 +49,8 @@ Tiling get_tiling(const Operation& operation, bool hack_tiling) {
   const char* k_dim_host_tiling_env = std::getenv("K_DIM_HOST_TILING");
   bool k_dim_host_tiling = k_dim_host_tiling_env && std::stoi(k_dim_host_tiling_env) == 1;
 
-  const char* zircon_input_padding_workaround_env = std::getenv("ZIRCON_INPUT_PADDING_WORKAROUND");
-  bool zircon_input_padding_workaround = zircon_input_padding_workaround_env && std::stoi(zircon_input_padding_workaround_env) == 1;
+  const char* zircon_input_act_padding_workaround_env = std::getenv("ZIRCON_INPUT_ACT_PADDING_WORKAROUND");
+  bool zircon_input_act_padding_workaround = zircon_input_act_padding_workaround_env && std::stoi(zircon_input_act_padding_workaround_env) == 1;
 
   Tiling tiling;
   if (manual_tiling || !operation.has_valid_tiling) {
@@ -102,15 +102,15 @@ Tiling get_tiling(const Operation& operation, bool hack_tiling) {
     }
 
     // Workaround to pad inputs to account for Zircon MU's inability to handle some layer shapes
-    if (zircon_input_padding_workaround && hack_tiling){
-      const char* zircon_input_padding_workaround_size_env = std::getenv("ZIRCON_INPUT_PADDING_WORKAROUND_SIZE");
-      int zircon_input_padding_workaround_size;
+    if (zircon_input_act_padding_workaround && hack_tiling){
+      const char* zircon_input_act_padding_workaround_size_env = std::getenv("ZIRCON_INPUT_ACT_PADDING_WORKAROUND_SIZE");
+      int zircon_input_act_padding_workaround_size;
 
-      if (zircon_input_padding_workaround_size_env) {
-        zircon_input_padding_workaround_size = std::stoi(zircon_input_padding_workaround_size_env);
+      if (zircon_input_act_padding_workaround_size_env) {
+        zircon_input_act_padding_workaround_size = std::stoi(zircon_input_act_padding_workaround_size_env);
       } else {
         throw std::runtime_error(
-            "Zircon input padding workaround requires ZIRCON_INPUT_PADDING_WORKAROUND_SIZE "
+            "Zircon input padding workaround requires ZIRCON_INPUT_ACT_PADDING_WORKAROUND_SIZE "
             "environment variable to be set.");
       }
 
@@ -121,8 +121,8 @@ Tiling get_tiling(const Operation& operation, bool hack_tiling) {
             "Code modifications will be necessary to proceed.");
       }
 
-      tiling.loops[1][tiling.x_loop_index[1]] += zircon_input_padding_workaround_size;
-      tiling.loops[1][tiling.y_loop_index[1]] += zircon_input_padding_workaround_size;
+      tiling.loops[1][tiling.x_loop_index[1]] += zircon_input_act_padding_workaround_size;
+      tiling.loops[1][tiling.y_loop_index[1]] += zircon_input_act_padding_workaround_size;
 
     }
   }

--- a/test/common/Utils.h
+++ b/test/common/Utils.h
@@ -37,11 +37,11 @@ float compare_arrays(std::any matrixA, std::string matrixA_name,
   spdlog::info("Writing gold data to file: {}\n", gold_data_filename);
 
 
-  std::string gold_binary_filename = "gold_data" + suffix + "raw";
-  // Delete the file if it exists
-  std::remove(gold_binary_filename.c_str());
-  std::ofstream gold_binary_file(gold_binary_filename, std::ios::binary);
-  spdlog::info("Writing gold binary data to file: {}\n", gold_binary_filename);
+  // std::string gold_binary_filename = "gold_data" + suffix + "raw";
+  // // Delete the file if it exists
+  // std::remove(gold_binary_filename.c_str());
+  // std::ofstream gold_binary_file(gold_binary_filename, std::ios::binary);
+  // spdlog::info("Writing gold binary data to file: {}\n", gold_binary_filename);
 
   // Records absolute differences
   int abs_diff_buckets[5] = {0, 0, 0, 0, 0};
@@ -68,18 +68,18 @@ float compare_arrays(std::any matrixA, std::string matrixA_name,
     gold_data_file << std::endl;
 
     // write gold data out to binary (raw) file
-    const uint8_t* ptr2 = reinterpret_cast<const uint8_t*>(matrixB_ptr) + index * size_of_typeB;
-    // Loop over data in 2-byte chunks
-    for (size_t i = 0; i + 1 < size_of_typeB; i += 2) {
-        uint16_t value;
-        std::memcpy(&value, ptr2 + i, sizeof(uint16_t));  // safely extract 2 bytes
+    // const uint8_t* ptr2 = reinterpret_cast<const uint8_t*>(matrixB_ptr) + index * size_of_typeB;
+    // // Loop over data in 2-byte chunks
+    // for (size_t i = 0; i + 1 < size_of_typeB; i += 2) {
+    //     uint16_t value;
+    //     std::memcpy(&value, ptr2 + i, sizeof(uint16_t));  // safely extract 2 bytes
 
-        uint8_t high_byte = (value >> 8) & 0xFF;
-        uint8_t low_byte  = value & 0xFF;
+    //     uint8_t high_byte = (value >> 8) & 0xFF;
+    //     uint8_t low_byte  = value & 0xFF;
 
-        gold_binary_file.put(static_cast<char>(high_byte));
-        gold_binary_file.put(static_cast<char>(low_byte));
-    }
+    //     gold_binary_file.put(static_cast<char>(high_byte));
+    //     gold_binary_file.put(static_cast<char>(low_byte));
+    // }
 
     // Write the two values + error scale indicator to file
     diffFile << a << " vs. " << b << " ";

--- a/test/toolchain/MatrixOps.h
+++ b/test/toolchain/MatrixOps.h
@@ -137,6 +137,22 @@ void MapMatrixOperation(const Operation &operation,
 
   Tiling tiling = get_tiling(operation, hack_tiling);
 
+  // FIXME: Temporary HACK
+  if (hack_tiling) {
+    tiling = {
+          .loops = {{1, 1, 8, 8, 1, 1}, {1, 1, 3, 3, 14, 14}},
+          .x_loop_index = {1, 5},
+          .y_loop_index = {0, 4},
+          .reduction_loop_index = {3, 0},
+          .weight_loop_index = {2, 1},
+          .fx_index = 3,
+          .fy_index = 2,
+          .weight_reuse_index = {4, 5},
+          .stride = 1,
+          .replication = false,
+      };
+  }
+
   // --------------DATA DUMPING FOR AHA FLOW-------------------//
   if (dump_tiling) {
     std::ofstream output_tiling_dump_file;

--- a/test/toolchain/MatrixOps.h
+++ b/test/toolchain/MatrixOps.h
@@ -137,22 +137,6 @@ void MapMatrixOperation(const Operation &operation,
 
   Tiling tiling = get_tiling(operation, hack_tiling);
 
-  // FIXME: Temporary HACK
-  if (hack_tiling) {
-    tiling = {
-          .loops = {{1, 1, 8, 8, 1, 1}, {1, 1, 3, 3, 14, 14}},
-          .x_loop_index = {1, 5},
-          .y_loop_index = {0, 4},
-          .reduction_loop_index = {3, 0},
-          .weight_loop_index = {2, 1},
-          .fx_index = 3,
-          .fy_index = 2,
-          .weight_reuse_index = {4, 5},
-          .stride = 1,
-          .replication = false,
-      };
-  }
-
   // --------------DATA DUMPING FOR AHA FLOW-------------------//
   if (dump_tiling) {
     std::ofstream output_tiling_dump_file;


### PR DESCRIPTION
This PR introduces code for host tiling along the k-dimension in Zircon. It is necessary to support some Conv5 layers whose weights are too large to be stored in the global buffer. Notably, when k-dim host tiling is applied, the gold check is altered such that zeros are inserted in locations that a given micro-kernel should not touch (i.e. should not overwrite in memory). It also introduces a workaround for the MU bug which appears on certain layer shapes in Conv5. 
Other miscellaneous code fixes are present, such as including auto-accepting anaconda's terms of service when creating a voyager environment.

Corresponding AHA PR: https://github.com/StanfordAHA/aha/pull/2065