### PR TITLE
Zircon compiler bump and im2col and general flow

### DIFF
--- a/codegen.mk
+++ b/codegen.mk
@@ -9,44 +9,46 @@ BLOCK_SIZE := $(shell [ $(IC_DIMENSION) -gt $(OC_DIMENSION) ] && echo $(IC_DIMEN
 # BLOCK_SIZE := 64
 MXINT8_FLAGS := --activation int8,qs=microscaling,bs=$(BLOCK_SIZE) --weight int8,qs=microscaling,bs=$(BLOCK_SIZE) --force_scale_power_of_two --bf16
 MXNF4_FLAGS := --activation nf4_5,qs=microscaling,bs=$(BLOCK_SIZE),scale=fp8_e5m3 --weight nf4_5,qs=microscaling,bs=$(BLOCK_SIZE),scale=fp8_e5m3 --bf16
+COMMON_FLAGS := --hardware_unrolling $(IC_DIMENSION),$(OC_DIMENSION)
 EXTRA_COMPILER_FLAGS ?=
+
 
 ################################################################################
 $(CODEGEN_DIR)/networks/resnet18/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python quantized-training/test/test_codegen.py resnet18 $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --output_dir $(dir $@) > $(dir $@)/codegen.log 2>&1
+	python quantized-training/test/test_codegen.py resnet18 $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) --conv2d_im2col $(COMMON_FLAGS) > $(dir $@)/codegen.log 2>&1
 
 $(CODEGEN_DIR)/networks/resnet50/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python quantized-training/test/test_codegen.py resnet50 $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --output_dir $(dir $@) > $(dir $@)/codegen.log 2>&1
+	python quantized-training/test/test_codegen.py resnet50 $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@)  $(COMMON_FLAGS) > $(dir $@)/codegen.log 2>&1
 
 $(CODEGEN_DIR)/networks/mobilebert/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python quantized-training/test/test_codegen.py mobilebert $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) --model_name_or_path models/mobilebert/mobilebert-tiny-sst2-bf16 $(EXTRA_COMPILER_FLAGS) --output_dir $(dir $@) > $(dir $@)/codegen.log 2>&1
+	python quantized-training/test/test_codegen.py mobilebert $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) --model_name_or_path models/mobilebert/mobilebert-tiny-sst2-bf16 $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) > $(dir $@)/codegen.log 2>&1
 
 $(CODEGEN_DIR)/networks/mobilebert_encoder/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python quantized-training/test/test_codegen.py mobilebert_encoder $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) --model_name_or_path models/mobilebert/mobilebert-tiny-sst2-bf16 $(EXTRA_COMPILER_FLAGS) --output_dir $(dir $@) > $(dir $@)/codegen.log 2>&1
+	python quantized-training/test/test_codegen.py mobilebert_encoder $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) --model_name_or_path models/mobilebert/mobilebert-tiny-sst2-bf16 $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) > $(dir $@)/codegen.log 2>&1
 
 $(CODEGEN_DIR)/networks/bert/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python quantized-training/test/test_codegen.py bert $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --output_dir $(dir $@) &> $(dir $@)codegen.log
+	python quantized-training/test/test_codegen.py bert $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) &> $(dir $@)codegen.log
 
 $(CODEGEN_DIR)/networks/llama/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python quantized-training/test/test_codegen.py llama_decoder $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --output_dir $(dir $@) &> $(dir $@)codegen.log
+	python quantized-training/test/test_codegen.py llama_decoder $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) &> $(dir $@)codegen.log
 
 $(CODEGEN_DIR)networks/vit/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python quantized-training/test/test_codegen.py vit $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --output_dir $(dir $@) &> $(dir $@)codegen.log
+	python quantized-training/test/test_codegen.py vit $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) &> $(dir $@)codegen.log
 
 $(CODEGEN_DIR)/networks/segformer/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python -u quantized-training/test/test_codegen.py segformer $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --output_dir $(dir $@) &> $(dir $@)codegen.log
+	python -u quantized-training/test/test_codegen.py segformer $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) &> $(dir $@)codegen.log
 
 $(CODEGEN_DIR)/networks/fakeconv2d/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python -u quantized-training/test/test_codegen.py fakeconv2d $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --output_dir $(dir $@) &> $(dir $@)codegen.log
+	python -u quantized-training/test/test_codegen.py fakeconv2d $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) &> $(dir $@)codegen.log
 
 
 ################################################################################
@@ -54,14 +56,14 @@ $(CODEGEN_DIR)/networks/fakeconv2d/%/model.txt: quantized-training/test/test_cod
 ################################################################################
 $(CODEGEN_DIR)/networks/gesture/CFLOAT/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python quantized-training/test/test_codegen.py gesture --model_name_or_path models/gesture/model.pth --output_dir $(dir $@) > $(dir $@)/codegen.log 2>&1
+	python quantized-training/test/test_codegen.py gesture --model_name_or_path models/gesture/model.pth --model_output_dir $(dir $@) > $(dir $@)/codegen.log 2>&1
 
 ################################################################################
 # Layer Tests
 ################################################################################
 test/compiler/networks/layertest/CFLOAT/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python quantized-training/test/test_codegen.py layertest --output_dir $(dir $@) > $(dir $@)/codegen.log 2>&1
+	python quantized-training/test/test_codegen.py layertest --model_output_dir $(dir $@) > $(dir $@)/codegen.log 2>&1
 
 ################################################################################
 # Tilings

--- a/codegen.mk
+++ b/codegen.mk
@@ -23,69 +23,69 @@ endif
 ################################################################################
 $(CODEGEN_DIR)/networks/resnet18/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python quantized-training/test/test_codegen.py resnet18 $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) --conv2d_im2col $(COMMON_FLAGS) > $(dir $@)/codegen.log 2>&1
+	python quantized-training/test/test_codegen.py resnet18 $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) --conv2d_im2col $(COMMON_FLAGS) 2>&1 | tee $(dir $@)/codegen.log
 
 $(CODEGEN_DIR)/networks/resnet50/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python quantized-training/test/test_codegen.py resnet50 $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) > $(dir $@)/codegen.log 2>&1
+	python quantized-training/test/test_codegen.py resnet50 $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) 2>&1 | tee $(dir $@)/codegen.log
 
 $(CODEGEN_DIR)/networks/mobilebert/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python quantized-training/test/test_codegen.py mobilebert $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) --model_name_or_path models/mobilebert/mobilebert-tiny-sst2-bf16 $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) > $(dir $@)/codegen.log 2>&1
+	python quantized-training/test/test_codegen.py mobilebert $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) --model_name_or_path models/mobilebert/mobilebert-tiny-sst2-bf16 $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) 2>&1 | tee $(dir $@)/codegen.log
 
 $(CODEGEN_DIR)/networks/mobilebert_encoder/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python quantized-training/test/test_codegen.py mobilebert $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) --model_name_or_path models/mobilebert/mobilebert-tiny-sst2-bf16 $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) --remove_duplicate > $(dir $@)/codegen.log 2>&1
+	python quantized-training/test/test_codegen.py mobilebert $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) --model_name_or_path models/mobilebert/mobilebert-tiny-sst2-bf16 $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) --remove_duplicate 2>&1 | tee $(dir $@)/codegen.log
 
 $(CODEGEN_DIR)/networks/bert/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python quantized-training/test/test_codegen.py bert $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) &> $(dir $@)codegen.log
+	python quantized-training/test/test_codegen.py bert $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) 2>&1 | tee $(dir $@)/codegen.log
 
 $(CODEGEN_DIR)/networks/llama_prefill/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python quantized-training/test/test_codegen.py llm_prefill $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) $(LLM_FLAGS) &> $(dir $@)codegen.log
+	python quantized-training/test/test_codegen.py llm_prefill $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) $(LLM_FLAGS) 2>&1 | tee $(dir $@)/codegen.log
 
 $(CODEGEN_DIR)/networks/llama_decode/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python quantized-training/test/test_codegen.py llm_decode $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) $(LLM_FLAGS) &> $(dir $@)codegen.log
+	python quantized-training/test/test_codegen.py llm_decode $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) $(LLM_FLAGS) 2>&1 | tee $(dir $@)/codegen.log
 
 $(CODEGEN_DIR)/networks/llama_prefill_mp/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python quantized-training/test/test_codegen.py llm_prefill $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) $(LLM_FLAGS) --mixed_precision &> $(dir $@)codegen.log
+	python quantized-training/test/test_codegen.py llm_prefill $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) $(LLM_FLAGS) --mixed_precision 2>&1 | tee $(dir $@)/codegen.log
 
 $(CODEGEN_DIR)/networks/llama_decode_mp/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python quantized-training/test/test_codegen.py llm_decode $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) $(LLM_FLAGS) --mixed_precision &> $(dir $@)codegen.log
+	python quantized-training/test/test_codegen.py llm_decode $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) $(LLM_FLAGS) --mixed_precision 2>&1 | tee $(dir $@)/codegen.log
 
 $(CODEGEN_DIR)/networks/vit/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python quantized-training/test/test_codegen.py vit $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) &> $(dir $@)codegen.log
+	python quantized-training/test/test_codegen.py vit $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) 2>&1 | tee $(dir $@)/codegen.log
 
 $(CODEGEN_DIR)/networks/segformer/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python -u quantized-training/test/test_codegen.py segformer $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) &> $(dir $@)codegen.log
+	python -u quantized-training/test/test_codegen.py segformer $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) 2>&1 | tee $(dir $@)/codegen.log
 
 $(CODEGEN_DIR)/networks/fakeconv2d/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python -u quantized-training/test/test_codegen.py fakeconv2d $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) &> $(dir $@)codegen.log
+	python -u quantized-training/test/test_codegen.py fakeconv2d $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) 2>&1 | tee $(dir $@)/codegen.log
 
 ################################################################################
 # Gesture
 ################################################################################
 $(CODEGEN_DIR)/networks/gesture/CFLOAT/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python quantized-training/test/test_codegen.py gesture --model_name_or_path models/gesture/model.pth --model_output_dir $(dir $@) > $(dir $@)/codegen.log 2>&1
+	python quantized-training/test/test_codegen.py gesture --model_name_or_path models/gesture/model.pth --model_output_dir $(dir $@) 2>&1 | tee $(dir $@)/codegen.log
 
 ################################################################################
 # Layer Tests
 ################################################################################
 test/compiler/networks/layertest/CFLOAT/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python quantized-training/test/test_codegen.py layertest --model_output_dir $(dir $@) > $(dir $@)/codegen.log 2>&1
+	python quantized-training/test/test_codegen.py layertest --model_output_dir $(dir $@) 2>&1 | tee $(dir $@)/codegen.log
 
 ################################################################################
 # Tilings
 ################################################################################
 $(CODEGEN_DIR)/networks/$(NETWORK)/$(DATATYPE)/$(IC_DIMENSION)x$(OC_DIMENSION)_$(INPUT_BUFFER_SIZE)x$(WEIGHT_BUFFER_SIZE)x$(ACCUM_BUFFER_SIZE)_$(DOUBLE_BUFFERED_ACCUM_BUFFER)/tilings.txtpb: $(CODEGEN_DIR)/networks/$(NETWORK)/$(DATATYPE)/model.txt test/compiler/run_tiler.py test/compiler/proto/tiling_pb2.py
 	mkdir -p $(dir $@)
-	python test/compiler/run_tiler.py --codegen_dir $(dir $<) --IC_dimension $(IC_DIMENSION) --OC_dimension $(OC_DIMENSION) --input_buffer_size $(INPUT_BUFFER_SIZE) --weight_buffer_size $(WEIGHT_BUFFER_SIZE) --accum_buffer_size $(ACCUM_BUFFER_SIZE) $(if $(filter true,$(DOUBLE_BUFFERED_ACCUM_BUFFER)), --double_buffered_accum_buffer) > $(dir $@)/tiler.log 2>&1
+	python test/compiler/run_tiler.py --codegen_dir $(dir $<) --IC_dimension $(IC_DIMENSION) --OC_dimension $(OC_DIMENSION) --input_buffer_size $(INPUT_BUFFER_SIZE) --weight_buffer_size $(WEIGHT_BUFFER_SIZE) --accum_buffer_size $(ACCUM_BUFFER_SIZE) $(if $(filter true,$(DOUBLE_BUFFERED_ACCUM_BUFFER)), --double_buffered_accum_buffer) 2>&1 | tee $(dir $@)/tiler.log

--- a/codegen.mk
+++ b/codegen.mk
@@ -3,15 +3,22 @@
 
 E4M3_FLAGS := --activation fp8_e4m3 --weight fp8_e4m3 --bf16
 P8_1_FLAGS := --activation posit8_1 --weight posit8_1 --bf16
-INT8_FLAGS := --activation int8,qs=per_tensor_symmetric --weight int8,qs=per_tensor_symmetric --bias int24 --bf16
-INT8_32_FLAGS := --activation int8,qs=per_tensor_symmetric --weight int8,qs=per_tensor_symmetric --bias int32 --bf16
+INT8_FLAGS := --activation int8,qs=per_tensor_symmetric --weight int8,qs=per_tensor_symmetric --bias int24 --bf16 --calibration_steps 10
+INT8_32_FLAGS := --activation int8,qs=per_tensor_symmetric --weight int8,qs=per_tensor_symmetric --bias int32 --bf16 --calibration_steps 10
 BLOCK_SIZE := $(shell [ $(IC_DIMENSION) -gt $(OC_DIMENSION) ] && echo $(IC_DIMENSION) || echo $(OC_DIMENSION))
-# BLOCK_SIZE := 64
 MXINT8_FLAGS := --activation int8,qs=microscaling,bs=$(BLOCK_SIZE) --weight int8,qs=microscaling,bs=$(BLOCK_SIZE) --force_scale_power_of_two --bf16
-MXNF4_FLAGS := --activation nf4_5,qs=microscaling,bs=$(BLOCK_SIZE),scale=fp8_e5m3 --weight nf4_5,qs=microscaling,bs=$(BLOCK_SIZE),scale=fp8_e5m3 --bf16
-COMMON_FLAGS := --hardware_unrolling $(IC_DIMENSION),$(OC_DIMENSION)
+MXNF4_FLAGS := --activation nf4_6,qs=microscaling,bs=$(BLOCK_SIZE),scale=fp8_e5m3 --weight nf4_6,qs=microscaling,bs=$(BLOCK_SIZE),scale=fp8_e5m3 --bf16
+COMMON_FLAGS := --transpose_weight --hardware_unrolling $(IC_DIMENSION),$(OC_DIMENSION)
+LLM_FLAGS := --context_length 512 --remove_duplicate
 EXTRA_COMPILER_FLAGS ?=
 
+# Set default values if not already defined in the environment
+CACHE_SIZE ?= 4194304
+NUM_BANKS  ?= 8
+
+ifeq ($(SOC_SIM),1)
+COMMON_FLAGS += --cache_size $(CACHE_SIZE) --num_banks $(NUM_BANKS)
+endif
 
 ################################################################################
 $(CODEGEN_DIR)/networks/resnet18/%/model.txt: quantized-training/test/test_codegen.py
@@ -20,7 +27,7 @@ $(CODEGEN_DIR)/networks/resnet18/%/model.txt: quantized-training/test/test_codeg
 
 $(CODEGEN_DIR)/networks/resnet50/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python quantized-training/test/test_codegen.py resnet50 $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@)  $(COMMON_FLAGS) > $(dir $@)/codegen.log 2>&1
+	python quantized-training/test/test_codegen.py resnet50 $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) > $(dir $@)/codegen.log 2>&1
 
 $(CODEGEN_DIR)/networks/mobilebert/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
@@ -28,17 +35,29 @@ $(CODEGEN_DIR)/networks/mobilebert/%/model.txt: quantized-training/test/test_cod
 
 $(CODEGEN_DIR)/networks/mobilebert_encoder/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python quantized-training/test/test_codegen.py mobilebert_encoder $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) --model_name_or_path models/mobilebert/mobilebert-tiny-sst2-bf16 $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) > $(dir $@)/codegen.log 2>&1
+	python quantized-training/test/test_codegen.py mobilebert $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) --model_name_or_path models/mobilebert/mobilebert-tiny-sst2-bf16 $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) --remove_duplicate > $(dir $@)/codegen.log 2>&1
 
 $(CODEGEN_DIR)/networks/bert/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
 	python quantized-training/test/test_codegen.py bert $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) &> $(dir $@)codegen.log
 
-$(CODEGEN_DIR)/networks/llama/%/model.txt: quantized-training/test/test_codegen.py
+$(CODEGEN_DIR)/networks/llama_prefill/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
-	python quantized-training/test/test_codegen.py llama_decoder $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) &> $(dir $@)codegen.log
+	python quantized-training/test/test_codegen.py llm_prefill $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) $(LLM_FLAGS) &> $(dir $@)codegen.log
 
-$(CODEGEN_DIR)networks/vit/%/model.txt: quantized-training/test/test_codegen.py
+$(CODEGEN_DIR)/networks/llama_decode/%/model.txt: quantized-training/test/test_codegen.py
+	mkdir -p $(dir $@)
+	python quantized-training/test/test_codegen.py llm_decode $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) $(LLM_FLAGS) &> $(dir $@)codegen.log
+
+$(CODEGEN_DIR)/networks/llama_prefill_mp/%/model.txt: quantized-training/test/test_codegen.py
+	mkdir -p $(dir $@)
+	python quantized-training/test/test_codegen.py llm_prefill $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) $(LLM_FLAGS) --mixed_precision &> $(dir $@)codegen.log
+
+$(CODEGEN_DIR)/networks/llama_decode_mp/%/model.txt: quantized-training/test/test_codegen.py
+	mkdir -p $(dir $@)
+	python quantized-training/test/test_codegen.py llm_decode $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) $(LLM_FLAGS) --mixed_precision &> $(dir $@)codegen.log
+
+$(CODEGEN_DIR)/networks/vit/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
 	python quantized-training/test/test_codegen.py vit $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) &> $(dir $@)codegen.log
 
@@ -49,7 +68,6 @@ $(CODEGEN_DIR)/networks/segformer/%/model.txt: quantized-training/test/test_code
 $(CODEGEN_DIR)/networks/fakeconv2d/%/model.txt: quantized-training/test/test_codegen.py
 	mkdir -p $(dir $@)
 	python -u quantized-training/test/test_codegen.py fakeconv2d $($(notdir $(patsubst %/,%,$(dir $@)))_FLAGS) $(EXTRA_COMPILER_FLAGS) --model_output_dir $(dir $@) $(COMMON_FLAGS) &> $(dir $@)codegen.log
-
 
 ################################################################################
 # Gesture
@@ -68,6 +86,6 @@ test/compiler/networks/layertest/CFLOAT/model.txt: quantized-training/test/test_
 ################################################################################
 # Tilings
 ################################################################################
-$(CODEGEN_DIR)/networks/$(NETWORK)/$(DATATYPE)/$(IC_DIMENSION)x$(OC_DIMENSION)_$(INPUT_BUFFER_SIZE)x$(WEIGHT_BUFFER_SIZE)x$(ACCUM_BUFFER_SIZE)_$(DOUBLE_BUFFERED_ACCUM_BUFFER)/tilings.txtpb: $(CODEGEN_DIR)/networks/$(NETWORK)/$(DATATYPE)/model.txt test/compiler/run_tiler.py
+$(CODEGEN_DIR)/networks/$(NETWORK)/$(DATATYPE)/$(IC_DIMENSION)x$(OC_DIMENSION)_$(INPUT_BUFFER_SIZE)x$(WEIGHT_BUFFER_SIZE)x$(ACCUM_BUFFER_SIZE)_$(DOUBLE_BUFFERED_ACCUM_BUFFER)/tilings.txtpb: $(CODEGEN_DIR)/networks/$(NETWORK)/$(DATATYPE)/model.txt test/compiler/run_tiler.py test/compiler/proto/tiling_pb2.py
 	mkdir -p $(dir $@)
 	python test/compiler/run_tiler.py --codegen_dir $(dir $<) --IC_dimension $(IC_DIMENSION) --OC_dimension $(OC_DIMENSION) --input_buffer_size $(INPUT_BUFFER_SIZE) --weight_buffer_size $(WEIGHT_BUFFER_SIZE) --accum_buffer_size $(ACCUM_BUFFER_SIZE) $(if $(filter true,$(DOUBLE_BUFFERED_ACCUM_BUFFER)), --double_buffered_accum_buffer) > $(dir $@)/tiler.log 2>&1

--- a/run_regression.py
+++ b/run_regression.py
@@ -599,6 +599,7 @@ def run_accuracy(model, dataset, num_processes, output_folder):
                 "quantized-training/test/test_codegen.py",
                 model,
                 "--model_name_or_path",
+                "--transpose_weight",
                 model_path,
                 *quantization_args,
                 "--output_dir",

--- a/run_regression.py
+++ b/run_regression.py
@@ -176,16 +176,24 @@ def run_systemc_unit_test(model, layer, output_folder, fast, scale_down_operatio
 
     with open(f"{output_folder}/{model}_{layer}.log", "w") as stdout_file:
         try:
-            subprocess.run(
+            process = subprocess.Popen(
                 ["make", "fast-sim" if fast else "sim"],
                 env=env_vars,
-                stdout=stdout_file,
+                stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
-                timeout=1 * 60 * 60,
+                text=True,
             )
+
+            for line in process.stdout:
+                print(line, end="")        # print to terminal
+                stdout_file.write(line)    # write to file
+
+            process.wait(timeout=1 * 60 * 60)
+
         except subprocess.TimeoutExpired:
             print(f"Test {model}_{layer} timed out")
-            stdout_file.write("Test timed out")
+            stdout_file.write("Test timed out\n")
+            process.kill()
 
     # search if the test passed
     p = subprocess.Popen(
@@ -206,12 +214,19 @@ def run_systemc_tests(layers, condensed_models, num_processes, results_folder, f
     subprocess.run(["make", "clean"], env=os.environ)
 
     with open(f"{results_folder}/build.log", "w") as stdout_file:
-        subprocess.run(
+        process = subprocess.Popen(
             ["make", "-j", "TestRunner-fast" if fast else "TestRunner"],
             env=env_vars,
-            stdout=stdout_file,
+            stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
+            text=True,
         )
+
+        for line in process.stdout:
+            print(line, end="")        # show on terminal
+            stdout_file.write(line)    # also save to log
+
+        process.wait()
 
     pool = mp.Pool(num_processes)
 

--- a/run_regression.py
+++ b/run_regression.py
@@ -742,7 +742,7 @@ def add_layers(network, layers, layer_counts, uniquify):
                 layer_counts[network][name] = 1
 
 
-def append_glb_base_addresses(kwargs, mu_glb_base_address):
+def append_glb_base_addresses(tensor_metadata, kwargs, mu_glb_base_address, is_gemm=False):
     zircon_fx_fy_stride_workaround = "ZIRCON_FX_FY_STRIDE_WORKAROUND" in os.environ and os.environ["ZIRCON_FX_FY_STRIDE_WORKAROUND"] == "1"
     zircon_input_act_padding_workaround = "ZIRCON_INPUT_ACT_PADDING_WORKAROUND" in os.environ and os.environ["ZIRCON_INPUT_ACT_PADDING_WORKAROUND"] == "1"
     if zircon_input_act_padding_workaround:
@@ -755,46 +755,73 @@ def append_glb_base_addresses(kwargs, mu_glb_base_address):
 
     # Append GLB base addresses to the kwargs for input, weight, bias, inputScale, and weightScale tensors
     input_base_address = mu_glb_base_address
+    curr_addr_pointer = input_base_address
 
     # multiply all element in kwargs['input']['tensor']['shape'] together and add to input_base_address
     input_num_elements = functools.reduce(operator.mul, kwargs['input']['tensor']['shape'], 1)
     if zircon_input_act_padding_workaround:
         input_shape = kwargs['input']['tensor']['shape']
         input_num_elements = input_shape[0] * input_shape[1] * (input_shape[2] + zircon_input_act_padding_workaround_size) * (input_shape[3] + zircon_input_act_padding_workaround_size)
-    inputScale_base_address = input_base_address + math.ceil(input_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
+    curr_addr_pointer = input_base_address + math.ceil(input_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
 
-    inputScale_num_elements = functools.reduce(operator.mul, kwargs['input_scale']['tensor']['shape'], 1)
-    if zircon_input_act_padding_workaround:
-        inputScale_shape = kwargs['input_scale']['tensor']['shape']
-        inputScale_num_elements = inputScale_shape[0] * inputScale_shape[1] * (inputScale_shape[2] + zircon_input_act_padding_workaround_size) * (inputScale_shape[3] + zircon_input_act_padding_workaround_size)
-    weight_base_address = inputScale_base_address + math.ceil(inputScale_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
 
+    if 'input_scale' in kwargs and 'tensor' in kwargs['input_scale'] and 'shape' in kwargs['input_scale']['tensor']:
+        inputScale_num_elements = functools.reduce(operator.mul, kwargs['input_scale']['tensor']['shape'], 1)
+        if zircon_input_act_padding_workaround:
+            inputScale_shape = kwargs['input_scale']['tensor']['shape']
+            inputScale_num_elements = inputScale_shape[0] * inputScale_shape[1] * (inputScale_shape[2] + zircon_input_act_padding_workaround_size) * (inputScale_shape[3] + zircon_input_act_padding_workaround_size)
+        inputScale_base_address = curr_addr_pointer
+        curr_addr_pointer += math.ceil(inputScale_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
+
+    if is_gemm:
+        kwargs['weight'] = kwargs['other']  # rename 'other' to 'weight' for consistency
+        del kwargs['other']  # remove 'other' from kwargs
     weight_num_elements = functools.reduce(operator.mul, kwargs['weight']['tensor']['shape'], 1)
     if k_dim_host_tiling:
         weight_num_elements = weight_num_elements // num_k_host_tiling_kernels
     if zircon_fx_fy_stride_workaround:
         weight_num_elements *= 3 * 3
-    weightScale_base_address = weight_base_address + math.ceil(weight_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
+    weight_base_address = curr_addr_pointer
+    curr_addr_pointer += math.ceil(weight_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
 
-    weightScale_num_elements = functools.reduce(operator.mul, kwargs['weight_scale']['tensor']['shape'], 1)
-    if k_dim_host_tiling:
-        weightScale_num_elements = weightScale_num_elements // num_k_host_tiling_kernels
-    if zircon_fx_fy_stride_workaround:
-        weightScale_num_elements *= 3 * 3
+    if 'weight_scale' in kwargs and 'tensor' in kwargs['weight_scale'] and 'shape' in kwargs['weight_scale']['tensor']:
+        weightScale_num_elements = functools.reduce(operator.mul, kwargs['weight_scale']['tensor']['shape'], 1)
+        if k_dim_host_tiling:
+            weightScale_num_elements = weightScale_num_elements // num_k_host_tiling_kernels
+        if zircon_fx_fy_stride_workaround:
+            weightScale_num_elements *= 3 * 3
+        weightScale_base_address = curr_addr_pointer
+        curr_addr_pointer += math.ceil(weightScale_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
 
-    bias_base_address = weightScale_base_address + math.ceil(weightScale_num_elements/32) * 32 # take math.ceil(/32) * 32 to align to 32 bytes in MU-GLB address space
+    if 'bias' in kwargs:
+        bias_base_address = curr_addr_pointer
 
-    kwargs['input']['tensor']['glb_base_address'] = input_base_address
-    kwargs['input_scale']['tensor']['glb_base_address'] = inputScale_base_address
-    kwargs['weight']['tensor']['glb_base_address'] = weight_base_address
-    kwargs['weight_scale']['tensor']['glb_base_address'] = weightScale_base_address
-    kwargs['bias']['tensor']['glb_base_address'] = bias_base_address
+    if 'input' in kwargs:
+        kwargs['input']['tensor']['glb_base_address'] = input_base_address
+        tensor_metadata["has_input"] = True
+    if 'input_scale' in kwargs:
+        kwargs['input_scale']['tensor']['glb_base_address'] = inputScale_base_address
+        tensor_metadata["has_input_scale"] = True
+    if 'weight' in kwargs:
+        kwargs['weight']['tensor']['glb_base_address'] = weight_base_address
+        tensor_metadata["has_weight"] = True
+    if 'weight_scale' in kwargs:
+        kwargs['weight_scale']['tensor']['glb_base_address'] = weightScale_base_address
+        tensor_metadata["has_weight_scale"] = True
+    if 'bias' in kwargs:
+        kwargs['bias']['tensor']['glb_base_address'] = bias_base_address
+        tensor_metadata["has_bias"] = True
 
 
 def create_tensor_metadata_json(layer, params_dict):
     # create tensor_metadata.json file, needed by aha flow
     tensor_metadata = {
         "layer_name": layer,
+        "has_input": True,
+        "has_input_scale": False,
+        "has_weight": True,
+        "has_weight_scale": False,
+        "has_bias": False,
         "has_residual": False,
         "mu_glb_base_address": 0,
         "ops": [],
@@ -816,8 +843,8 @@ def create_tensor_metadata_json(layer, params_dict):
             op_dict["name"] = op["op"]["name"]
             op_dict["kwargs"] = op["op"]["kwargs"]
             # Should be if "conv2d" or if "matmul", etc. Generalize this in the future
-            if "conv2d" in op_dict["name"]:
-                append_glb_base_addresses(op_dict["kwargs"], mu_glb_base_address)
+            if "conv2d" in op_dict["name"] or "matmul" in op_dict["name"]:
+                append_glb_base_addresses(tensor_metadata, op_dict["kwargs"], mu_glb_base_address, is_gemm="matmul" in op_dict["name"])
             for arg_key in op_dict["kwargs"]:
                     arg = op_dict["kwargs"][arg_key]
                     tensor = arg.get("tensor")
@@ -836,8 +863,8 @@ def create_tensor_metadata_json(layer, params_dict):
                     tensor_metadata["has_residual"] = True
                 fused_op_dict["kwargs"] = fused_op["kwargs"]
                 # Should be if "conv2d" or if "matmul", etc. Generalize this in the future
-                if "conv2d" in fused_op_dict["name"]:
-                    append_glb_base_addresses(fused_op_dict["kwargs"], mu_glb_base_address)
+                if "conv2d" in fused_op_dict["name"] or "matmul" in fused_op_dict["name"]:
+                    append_glb_base_addresses(tensor_metadata, fused_op_dict["kwargs"], mu_glb_base_address, is_gemm="matmul" in fused_op_dict["name"])
                 for arg_key in fused_op_dict["kwargs"]:
                     arg = fused_op_dict["kwargs"][arg_key]
                     tensor = arg.get("tensor")

--- a/scripts/aha_flow/compare_load_data.py
+++ b/scripts/aha_flow/compare_load_data.py
@@ -44,6 +44,23 @@ def read_bytes_from_waveform(file_path):
     return all_bytes
 
 
+def read_bfloat16_data_from_waveform(file_path):
+    all_16b_data = []
+
+    with open(file_path, "r") as file:
+        for line in file:
+            if "=" in line:
+                hex_data = line.split("=")[-1].strip().replace(" ", "")
+                # Break into bytes (4 hex chars), LSB first
+                bytes_list = [hex_data[i:i+4] for i in range(0, len(hex_data), 4)]
+                bytes_list.reverse()  # LSB first
+                all_16b_data.extend(bytes_list)
+
+
+    float_array = np.array([bfbin2float(bin(int(x, 16))[2:].zfill(16)) for x in all_16b_data], dtype=np.float32)
+    return float_array
+
+
 def read_bytes_from_systemC(file_path):
     all_bytes = []
 
@@ -110,44 +127,67 @@ def compare_floating_point_data(data1, data2, name):
     print(f"{name} match!")
 
 
+def trim_bogus_output(systolic_array_data_out):
+    trimmed_output = []
+    bogus_count = 1
+    K2 = 16
+    Y = 8
+    X = 8
+    K0 = 32
+    for k2 in range(K2):
+        for y in range(Y):
+            for x in range(X):
+                for k0 in range(K0):
+                    if (y < Y-bogus_count and x < X-bogus_count):
+                        index = (k2 * Y * X * K0) + (y * X * K0) + (x * K0) + k0
+                        trimmed_output.append(systolic_array_data_out[index])
+    return np.array(trimmed_output, dtype=np.float32)
+
+
 
 if __name__ == "__main__":
     # input_data_mu_in = read_bytes_from_waveform("/aha/garnet/tests/test_app/input_data_mu_in.txt")
-    # weight_data_mu_in = read_bytes_from_waveform("/aha/garnet/tests/test_app/weight_data_mu_in.txt")
-    # bias_data_mu_in = read_bytes_from_waveform("/aha/garnet/tests/test_app/bias_data_mu_in.txt")
+    weight_data_mu_in = read_bytes_from_waveform("/aha/garnet/tests/test_app/weight_data_mu_in.txt")
+    bias_data_mu_in = read_bytes_from_waveform("/aha/garnet/tests/test_app/bias_data_mu_in.txt")
     # inputScale_data_mu_in = read_bytes_from_waveform("/aha/garnet/tests/test_app/inputScale_data_mu_in.txt")
-    # weightScale_data_mu_in = read_bytes_from_waveform("/aha/garnet/tests/test_app/weightScale_data_mu_in.txt")
+    weightScale_data_mu_in = read_bytes_from_waveform("/aha/garnet/tests/test_app/weightScale_data_mu_in.txt")
 
-    # # systolic_array_data_out = read_bytes_from_waveform("/aha/garnet/tests/test_app/systolic_array_output.txt")
+    systolic_array_data_out = read_bfloat16_data_from_waveform("/aha/garnet/tests/test_app/systolic_array_output.txt")
+    systolic_array_data_out = trim_bogus_output(systolic_array_data_out)
+    # breakpoint()
+
+
     # # print(len(systolic_array_data_out))
 
 
-    # input_data_systemC = read_bytes_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_6/compare/input_data_systemC.txt")
-    # weight_data_systemC = read_bytes_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_6/compare/weight_data_systemC.txt")
-    # bias_data_systemC = read_bytes_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_6/compare/bias_data_systemC.txt")
-    # inputScale_data_systemC = read_bytes_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_6/compare/inputScale_data_systemC.txt")
-    # weightScale_data_systemC = read_bytes_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_6/compare/weightScale_data_systemC.txt")
+    # input_data_systemC = read_bytes_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_15/compare/input_data_systemC.txt")
+    weight_data_systemC = read_bytes_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_15/compare/weight_data_systemC.txt")
+    bias_data_systemC = read_bytes_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_15/compare/bias_data_systemC.txt")
+    # inputScale_data_systemC = read_bytes_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_15/compare/inputScale_data_systemC.txt")
+    weightScale_data_systemC = read_bytes_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_15/compare/weightScale_data_systemC.txt")
 
-    SA_output_systemC = read_SA_output_from_systemC("/aha/SA_output_systemC.txt")
+    SA_output_systemC = read_SA_output_from_systemC("/aha/voyager/compiled_collateral/resnet18-submodule_15/compare/SA_output_systemC.txt")
+    # breakpoint()
 
 
 
-    glb_hw_output = read_bytes_from_hw_output_txt("/aha/garnet/tests/test_app/hw_output.txt")
+    # glb_hw_output = read_bytes_from_hw_output_txt("/aha/garnet/tests/test_app/hw_output.txt")
 
-    # Reshape it to (Y1, Y0, X1, X0, K2, K1, K0=32)
-    glb_hw_output = glb_hw_output.reshape((1, 14, 1, 14, 8, 1, 32))
-    glb_hw_output = glb_hw_output.transpose(0, 2, 4, 5, 1, 3, 6)  # (Y1, X1, K2, K1, Y0, X0, K0=32)
-    glb_hw_output = glb_hw_output.flatten()  # Flatten to 1D array
+    # # Reshape it to (Y1, Y0, X1, X0, K2, K1, K0=32)
+    # glb_hw_output = glb_hw_output.reshape((1, 14, 1, 14, 8, 1, 32))
+    # glb_hw_output = glb_hw_output.transpose(0, 2, 4, 5, 1, 3, 6)  # (Y1, X1, K2, K1, Y0, X0, K0=32)
+    # glb_hw_output = glb_hw_output.flatten()  # Flatten to 1D array
 
 
     # compare_data(input_data_mu_in, input_data_systemC, "input_data")
-    # compare_data(weight_data_mu_in, weight_data_systemC, "weight_data")
-    # compare_data(bias_data_mu_in, bias_data_systemC, "bias_data")
+    compare_data(weight_data_mu_in, weight_data_systemC, "weight_data")
+    compare_data(bias_data_mu_in, bias_data_systemC, "bias_data")
     # compare_data(inputScale_data_mu_in, inputScale_data_systemC, "inputScale_data")
-    # compare_data(weightScale_data_mu_in, weightScale_data_systemC, "weightScale_data")
+    compare_data(weightScale_data_mu_in, weightScale_data_systemC, "weightScale_data")
 
 
-    compare_floating_point_data(SA_output_systemC, glb_hw_output, "systolic_array_output_float")
+    # compare_floating_point_data(SA_output_systemC, glb_hw_output, "systolic_array_output_float")
+    # compare_floating_point_data(SA_output_systemC, systolic_array_data_out, "systolic_array_output_float")
 
 
 

--- a/scripts/aha_flow/parse_dnnLayer_tensors.py
+++ b/scripts/aha_flow/parse_dnnLayer_tensors.py
@@ -137,6 +137,9 @@ def hw_output_txt_to_raw(input_txt_path, output_raw_path):
 
 
 def parse_zircon_workarounds():
+    # Workaround needed to avoid Zircon MU bug on Resnet downsample layers and in GEMM layers
+    zircon_inner_loop_reduction_workaround = "ZIRCON_INNER_LOOP_REDUCTION_WORKAROUND" in os.environ and os.environ["ZIRCON_INNER_LOOP_REDUCTION_WORKAROUND"] == "1"
+
     # Workarounds to avoid Zircon MU bug on Resnet downsample layers
     zircon_fx_fy_stride_workaround = "ZIRCON_FX_FY_STRIDE_WORKAROUND" in os.environ and os.environ["ZIRCON_FX_FY_STRIDE_WORKAROUND"] == "1"
     zircon_cgra_psum_workaround = "ZIRCON_CGRA_PSUM_WORKAROUND" in os.environ and os.environ["ZIRCON_CGRA_PSUM_WORKAROUND"] == "1"
@@ -154,6 +157,7 @@ def parse_zircon_workarounds():
     if zircon_input_act_padding_workaround:
         assert "ZIRCON_INPUT_ACT_PADDING_WORKAROUND_SIZE" in os.environ, "ZIRCON_INPUT_ACT_PADDING_WORKAROUND_SIZE environment variable must be set for ZIRCON_INPUT_ACT_PADDING_WORKAROUND"
         zircon_input_act_padding_workaround_size = int(os.environ.get("ZIRCON_INPUT_ACT_PADDING_WORKAROUND_SIZE"))
+        zircon_input_act_padding_workaround_stride = int(os.environ.get("ZIRCON_INPUT_ACT_PADDING_WORKAROUND_STRIDE", 1))
 
     # K dimension host tiling: used in resnet18 conv5 in Zircon
     k_dim_host_tiling = "K_DIM_HOST_TILING" in os.environ and os.environ["K_DIM_HOST_TILING"] == "1"
@@ -165,6 +169,9 @@ def parse_zircon_workarounds():
         num_k_host_tiling_kernels = int(os.environ.get("NUM_K_HOST_TILING_KERNELS"))
         k_dim_host_tiling_idx = int(os.environ.get("K_DIM_HOST_TILING_IDX"))
 
+    if zircon_inner_loop_reduction_workaround:
+        print("\033[93mINFO: Zircon inner loop reduction workaround enabled. The outer channel loop is moved to the inner level. This should only be used to avoid the Zircon MU bug on Resnet downsample layers and in GEMM layers.\033[0m")
+
     if zircon_cgra_psum_workaround:
         print(f"\033[93mINFO: Zircon CGRA PSUM workaround enabled to avoid MU bug on downsample layers. Using PSUM index {psum_idx}. There are {num_psums} total PSUMs.\033[0m")
 
@@ -172,7 +179,7 @@ def parse_zircon_workarounds():
         print("\033[93mINFO: Zircon FX, FY stride workaround enabled to avoid MU bug on downsample layers.\033[0m")
 
     if zircon_input_act_padding_workaround:
-        print(f"\033[93mINFO: Zircon input padding workaround enabled. Input image will be padded with +{zircon_input_act_padding_workaround_size}.\033[0m")
+        print(f"\033[93mINFO: Zircon input padding workaround enabled. Input image will be padded with +{zircon_input_act_padding_workaround_size}. The stride is {zircon_input_act_padding_workaround_stride}.\033[0m")
 
     if k_dim_host_tiling:
         print(f"\033[93mINFO: K dimension host tiling enabled. Using {num_k_host_tiling_kernels} kernels with index {k_dim_host_tiling_idx}.\033[0m")
@@ -185,6 +192,7 @@ def parse_zircon_workarounds():
         "num_psums": num_psums,
         "zircon_input_act_padding_workaround": zircon_input_act_padding_workaround,
         "zircon_input_act_padding_workaround_size": zircon_input_act_padding_workaround_size,
+        "zircon_input_act_padding_workaround_stride": zircon_input_act_padding_workaround_stride,
         "k_dim_host_tiling": k_dim_host_tiling,
         "num_k_host_tiling_kernels": num_k_host_tiling_kernels,
         "k_dim_host_tiling_idx": k_dim_host_tiling_idx
@@ -196,7 +204,8 @@ def parse_input(base_path, input_tensor_data, zircon_workarounds):
     input = read_tensor(base_path + input_tensor_data["node"] + ".bin", tuple(input_tensor_data["shape"]))
     if zircon_workarounds["zircon_input_act_padding_workaround"]:
         input = input.permute(0, 3, 1, 2)  # Re-order to (B, IC, Y, X)
-        input = F.pad(input, pad=(0, zircon_workarounds["zircon_input_act_padding_workaround_size"], 0, zircon_workarounds["zircon_input_act_padding_workaround_size"])) # Pad X and Y dimensions with zeros
+        pad_dim = zircon_workarounds["zircon_input_act_padding_workaround_size"] * zircon_workarounds["zircon_input_act_padding_workaround_stride"]
+        input = F.pad(input, pad=(0, pad_dim, 0, pad_dim)) # Pad X and Y dimensions with zeros
         input = input.permute(0, 2, 3, 1)  # Re-order back to (B, Y, X, IC)
     if zircon_workarounds["zircon_cgra_psum_workaround"]:
         input = input.reshape((input.shape[0], input.shape[1], input.shape[2], input.shape[3] // ZIRCON_MU_IC0, ZIRCON_MU_IC0))
@@ -211,7 +220,8 @@ def parse_inputScale(base_path, inputScale_tensor_data, zircon_workarounds):
     inputScale = read_tensor(base_path + inputScale_tensor_data["node"] + ".bin", tuple(inputScale_tensor_data["shape"]))
     if zircon_workarounds["zircon_input_act_padding_workaround"]:
         inputScale = inputScale.permute(0, 3, 1, 2)  # Re-order to (B, IC / BLOCK_SIZE, Y, X)
-        inputScale = F.pad(inputScale, pad=(0, zircon_workarounds["zircon_input_act_padding_workaround_size"], 0, zircon_workarounds["zircon_input_act_padding_workaround_size"])) # Pad X and Y dimensions with zeros
+        pad_dim = zircon_workarounds["zircon_input_act_padding_workaround_size"] * zircon_workarounds["zircon_input_act_padding_workaround_stride"]
+        inputScale = F.pad(inputScale, pad=(0, pad_dim, 0, pad_dim)) # Pad X and Y dimensions with zeros
         inputScale = inputScale.permute(0, 2, 3, 1)  # Re-order back to (B, Y, X, IC / BLOCK_SIZE)
     if zircon_workarounds["zircon_cgra_psum_workaround"]:
         inputScale = inputScale.permute(3, 0, 1, 2)

--- a/scripts/aha_flow/parse_dnnLayer_tensors.py
+++ b/scripts/aha_flow/parse_dnnLayer_tensors.py
@@ -192,69 +192,69 @@ def parse_zircon_workarounds():
 
 
 def parse_input(base_path, input_tensor_data, zircon_workarounds):
-    # Shape is in format: (OC, IC, Y, X)
+    # Shape is in format: (B, Y, X, IC)
     input = read_tensor(base_path + input_tensor_data["node"] + ".bin", tuple(input_tensor_data["shape"]))
     if zircon_workarounds["zircon_input_act_padding_workaround"]:
+        input = input.permute(0, 3, 1, 2)  # Re-order to (B, IC, Y, X)
         input = F.pad(input, pad=(0, zircon_workarounds["zircon_input_act_padding_workaround_size"], 0, zircon_workarounds["zircon_input_act_padding_workaround_size"])) # Pad X and Y dimensions with zeros
-    # Re-order it so IC is the innermost dimension (Y, X, OC, IC)
-    input_reordered = input.permute(2, 3, 0, 1)
+        input = input.permute(0, 2, 3, 1)  # Re-order back to (B, Y, X, IC)
     if zircon_workarounds["zircon_cgra_psum_workaround"]:
-        input_reordered = input_reordered.reshape((input.shape[2], input.shape[3], input.shape[0], input.shape[1] // ZIRCON_MU_IC0, ZIRCON_MU_IC0))
-        input_reordered = input_reordered.permute(3, 0, 1, 2, 4)
-    input_int8 = input_reordered.to(torch.int8)
+        input = input.reshape((input.shape[0], input.shape[1], input.shape[2], input.shape[3] // ZIRCON_MU_IC0, ZIRCON_MU_IC0))
+        input = input.permute(3, 0, 1, 2, 4)
+    input_int8 = input.to(torch.int8)
 
     return input_int8
 
 
 def parse_inputScale(base_path, inputScale_tensor_data, zircon_workarounds):
-    # Shape is in format: (OC, IC / BLOCK_SIZE, Y, X)
+    # Shape is in format: (B, Y, X, IC / BLOCK_SIZE)
     inputScale = read_tensor(base_path + inputScale_tensor_data["node"] + ".bin", tuple(inputScale_tensor_data["shape"]))
     if zircon_workarounds["zircon_input_act_padding_workaround"]:
+        inputScale = inputScale.permute(0, 3, 1, 2)  # Re-order to (B, IC / BLOCK_SIZE, Y, X)
         inputScale = F.pad(inputScale, pad=(0, zircon_workarounds["zircon_input_act_padding_workaround_size"], 0, zircon_workarounds["zircon_input_act_padding_workaround_size"])) # Pad X and Y dimensions with zeros
-    # Re-order it so IC is the innermost dimension (Y, X, OC, IC / BLOCK_SIZE)
-    inputScale_reordered = inputScale.permute(2, 3, 0, 1)
+        inputScale = inputScale.permute(0, 2, 3, 1)  # Re-order back to (B, Y, X, IC / BLOCK_SIZE)
     if zircon_workarounds["zircon_cgra_psum_workaround"]:
-        inputScale_reordered = inputScale_reordered.permute(3, 0, 1, 2)
-    inputScale_e8m0 = float_to_e8m0(inputScale_reordered)
+        inputScale = inputScale.permute(3, 0, 1, 2)
+    inputScale_e8m0 = float_to_e8m0(inputScale)
 
     return inputScale_e8m0
 
 def parse_weight(base_path, weight_tensor_data, zircon_workarounds):
-     # Shape is in format: (OC, IC, FY, FX)
+     # Shape is in format: (FY, FX, IC, OC)
     weight = read_tensor(base_path + weight_tensor_data["node"] + ".bin", tuple(weight_tensor_data["shape"]))
     if zircon_workarounds["zircon_fx_fy_stride_workaround"]:
+        weight = weight.permute(2, 3, 0, 1)  # Re-order to (IC, OC, FY, FX)
         weight = F.pad(weight, pad=(0, 2, 0, 2))
-    # Re-order it so OC is the innermost dimension (FY, FX, IC, OC)
-    weight_reordered = weight.permute(2, 3, 1, 0)
+        weight = weight.permute(2, 3, 0, 1)  # Re-order back to (FY, FX, IC, OC)
     if zircon_workarounds["zircon_cgra_psum_workaround"]:
-        weight_reordered = weight_reordered.reshape((weight.shape[2], weight.shape[3], weight.shape[1] // ZIRCON_MU_IC0, ZIRCON_MU_IC0, weight.shape[0]))
-        weight_reordered = weight_reordered.permute(2, 0, 1, 3, 4)
+        weight = weight.reshape((weight.shape[0], weight.shape[1], weight.shape[2] // ZIRCON_MU_IC0, ZIRCON_MU_IC0, weight.shape[3]))
+        weight = weight.permute(2, 0, 1, 3, 4)
     if zircon_workarounds["k_dim_host_tiling"]:
         num_k_host_tiling_kernels = zircon_workarounds["num_k_host_tiling_kernels"]
         k_dim_host_tiling_idx = zircon_workarounds["k_dim_host_tiling_idx"]
-        weight_reordered = weight_reordered.reshape((weight.shape[2], weight.shape[3], weight.shape[1], num_k_host_tiling_kernels, weight.shape[0] // num_k_host_tiling_kernels))
-        weight_reordered = weight_reordered.permute(3, 0, 1, 2, 4)
-        weight_reordered = weight_reordered[k_dim_host_tiling_idx]
-    weight_int8 = weight_reordered.to(torch.int8)
+        weight = weight.reshape((weight.shape[0], weight.shape[1], weight.shape[2], num_k_host_tiling_kernels, weight.shape[3] // num_k_host_tiling_kernels))
+        weight = weight.permute(3, 0, 1, 2, 4)
+        weight = weight[k_dim_host_tiling_idx]
+    weight_int8 = weight.to(torch.int8)
 
     return weight_int8
 
 def parse_weightScale(base_path, weightScale_tensor_data, zircon_workarounds):
-     # Shape is in format: (OC, IC / BLOCK_SIZE, FY, FX)
+     # Shape is in format: (FY, FX, IC / BLOCK_SIZE, OC)
     weightScale = read_tensor(base_path + weightScale_tensor_data["node"] + ".bin", tuple(weightScale_tensor_data["shape"]))
     if zircon_workarounds["zircon_fx_fy_stride_workaround"]:
+        weightScale = weightScale.permute(2, 3, 0, 1)  # Re-order to (IC / BLOCK_SIZE, OC, FY, FX)
         weightScale = F.pad(weightScale, pad=(0, 2, 0, 2))
-    # Re-order it so OC is the innermost dimension (FY, FX, IC / BLOCK_SIZE, OC)
-    weightScale_reordered = weightScale.permute(2, 3, 1, 0)
+        weightScale = weightScale.permute(2, 3, 0, 1)  # Re-order back to (FY, FX, IC / BLOCK_SIZE, OC)
     if zircon_workarounds["zircon_cgra_psum_workaround"]:
-        weightScale_reordered = weightScale_reordered.permute(2, 0, 1, 3)
+        weightScale = weightScale.permute(2, 0, 1, 3)
     if zircon_workarounds["k_dim_host_tiling"]:
         num_k_host_tiling_kernels = zircon_workarounds["num_k_host_tiling_kernels"]
         k_dim_host_tiling_idx = zircon_workarounds["k_dim_host_tiling_idx"]
-        weightScale_reordered = weightScale_reordered.reshape((weightScale.shape[2], weightScale.shape[3], weightScale.shape[1], num_k_host_tiling_kernels, weightScale.shape[0] // num_k_host_tiling_kernels))
-        weightScale_reordered = weightScale_reordered.permute(3, 0, 1, 2, 4)
-        weightScale_reordered = weightScale_reordered[k_dim_host_tiling_idx]
-    weightScale_e8m0 = float_to_e8m0(weightScale_reordered)
+        weightScale = weightScale.reshape((weightScale.shape[0], weightScale.shape[1], weightScale.shape[2], num_k_host_tiling_kernels, weightScale.shape[3] // num_k_host_tiling_kernels))
+        weightScale = weightScale.permute(3, 0, 1, 2, 4)
+        weightScale = weightScale[k_dim_host_tiling_idx]
+    weightScale_e8m0 = float_to_e8m0(weightScale)
 
     return weightScale_e8m0
 
@@ -262,10 +262,12 @@ def parse_bias(base_path, bias_tensor_data, zircon_workarounds):
     bias = read_tensor(base_path + bias_tensor_data["node"] + ".bin", tuple(bias_tensor_data["shape"]))
     if zircon_workarounds["zircon_cgra_psum_workaround"] and zircon_workarounds["psum_idx"] != 0:
         # If doing psum workaround, bias is zero for all but the 0th kernel
-        bias = torch.zeros((bias.shape[0],), dtype=torch.float32)
+        # TODO: This should be improved in the future to just set the MU->has_bias config to false for such kernels
+        bias = torch.zeros(tuple(bias_tensor_data["shape"]), dtype=torch.float32)
     if zircon_workarounds["k_dim_host_tiling"]:
         num_k_host_tiling_kernels = zircon_workarounds["num_k_host_tiling_kernels"]
         k_dim_host_tiling_idx = zircon_workarounds["k_dim_host_tiling_idx"]
+        bias = bias.flatten()
         bias = bias.reshape((num_k_host_tiling_kernels, bias.shape[0] // num_k_host_tiling_kernels))
         bias = bias[k_dim_host_tiling_idx]
     bias_bf16 = float32_to_bfloat16_bits(bias)
@@ -273,28 +275,29 @@ def parse_bias(base_path, bias_tensor_data, zircon_workarounds):
     return bias_bf16
 
 def parse_residual(base_path, residual_tensor_data, h2h_dir, zircon_workarounds):
-    # Shape is in format: (OC, IC, Y, X)
-    residual = read_tensor(base_path + residual_tensor_data["node"] + ".bin",
-                            (residual_tensor_data["shape"][0], residual_tensor_data["shape"][1], residual_tensor_data["shape"][2], residual_tensor_data["shape"][3]))
+    # Shape is in format: (B, Y, X, IC)
+    residual = read_tensor(base_path + residual_tensor_data["node"] + ".bin", tuple(residual_tensor_data["shape"]))
 
     if zircon_workarounds["zircon_fx_fy_stride_workaround"]:
+        residual = residual.permute(0, 3, 1, 2)  # Re-order to (B, IC, Y, X)
         residual_tmp = torch.zeros(residual.size(0), residual.size(1), 2*residual.size(2), 2*residual.size(3), device=residual.device, dtype=residual.dtype)
         # Place original values at odd indices (1, 3, 5, ...) using slicing
         residual_tmp[:, :, 1::2, 1::2] = residual
         residual = residual_tmp
+        residual = residual.permute(0, 2, 3, 1)  # Re-order back to (B, Y, X, IC)
 
     if zircon_workarounds["zircon_input_act_padding_workaround"]:
+        residual = residual.permute(0, 3, 1, 2)  # Re-order to (B, IC, Y, X)
         residual = F.pad(residual, pad=(0, zircon_workarounds["zircon_input_act_padding_workaround_size"], 0, zircon_workarounds["zircon_input_act_padding_workaround_size"]), value=-1000) # Pad with -1000 instead of 0s to catch potential bugs
+        residual = residual.permute(0, 2, 3, 1)  # Re-order back to (B, Y, X, IC)
 
-    # Re-order it so IC is the innermost dimension (Y, X, OC, IC)
-    residual_reordered = residual.permute(2, 3, 0, 1)
     if zircon_workarounds["k_dim_host_tiling"]:
         num_k_host_tiling_kernels = zircon_workarounds["num_k_host_tiling_kernels"]
         k_dim_host_tiling_idx = zircon_workarounds["k_dim_host_tiling_idx"]
-        residual_reordered = residual_reordered.reshape((residual.shape[2], residual.shape[3], residual.shape[0], num_k_host_tiling_kernels, residual.shape[1] // num_k_host_tiling_kernels))
-        residual_reordered = residual_reordered.permute(3, 0, 1, 2, 4)
-        residual_reordered = residual_reordered[k_dim_host_tiling_idx]
-    residual_bf16 = float32_to_bfloat16_bits(residual_reordered)
+        residual = residual.reshape((residual.shape[0], residual.shape[1], residual.shape[2], num_k_host_tiling_kernels, residual.shape[3] // num_k_host_tiling_kernels))
+        residual = residual.permute(3, 0, 1, 2, 4)
+        residual = residual[k_dim_host_tiling_idx]
+    residual_bf16 = float32_to_bfloat16_bits(residual)
     residual_bf16_be = residual_bf16.byteswap().newbyteorder('>')
 
     if zircon_workarounds["zircon_cgra_psum_workaround"] and (zircon_workarounds["psum_idx"] == 0):

--- a/scripts/aha_flow/parse_dnnLayer_tensors.py
+++ b/scripts/aha_flow/parse_dnnLayer_tensors.py
@@ -13,6 +13,8 @@ import json
 # converts them from float32 to int8, bfloat16, and e8m0 formats, tranposes them to the required layout in memory, allocates GLB memory for each tensor, and writes them to hex files
 # consumable by the AHA flow.
 
+ZIRCON_MU_IC0 = 64
+
 def read_tensor(filename, tensor_shape):
     with open(filename, 'rb') as f:
         file_content = f.read()
@@ -49,6 +51,7 @@ def float32_to_bfloat16_bits(x):
 def write_list_to_hex(list, filename, start_addr=0):
    #Write the entire tensor in hex format to a new file
    with open(filename, 'w') as output_file:
+        output_file.write(f"TENSOR_EXISTS: 1\n")
         output_file.write(f"SIZE: {len(list)}\n")
         output_file.write(f"START_ADDR: {start_addr}\n")
         for idx in range(len(list)):
@@ -57,48 +60,64 @@ def write_list_to_hex(list, filename, start_addr=0):
             if idx != len(list) - 1:
                 output_file.write("\n")
 
-def debug_print_tensors(
-            input, input_int8, bias, bias_bf16, inputScale, inputScale_e8m0,
-            weightScale, weightScale_e8m0, weight):
-    # Print first 10 elements and max value
+def debug_print_tensors(input, input_int8, bias_bf16, inputScale_e8m0, weightScale_e8m0):
+        # Print first 10 elements and max value
         print("First 10 elements of the input tensor:", input.flatten()[:10])
         print("Max value of the input tensor:", torch.max(input))
 
         print("First 10 elements of the input INT8 tensor:", input_int8.flatten()[:10])
         print("Max value of the input INT8 tensor:", torch.max(input_int8))
 
-        print("First 10 elements of the bias tensor:", bias.flatten()[:10])
-        print("Max value of the bias tensor:", torch.max(bias))
-
         print("First 10 elements of the bias bFloat16 tensor:", bias_bf16.flatten()[:10])
-        print("First 10 elements of the inputScale tensor:", inputScale.flatten()[:10])
-        print("Max value of the inputScale tensor:", torch.max(inputScale))
-        print("Min value of the inputScale tensor:", torch.min(inputScale))
 
         print("First 10 elements of the inputScale e8m0 tensor:", inputScale_e8m0.flatten()[:10])
 
-        print("First 10 elements of the weightScale tensor:", weightScale.flatten()[:10])
-        print("Max value of the weightScale tensor:", torch.max(weightScale))
-        print("Min value of the weightScale tensor:", torch.min(weightScale))
-
         print("First 10 elements of the weightScale e8m0 tensor:", weightScale_e8m0.flatten()[:10])
 
-        print("First 10 elements of the weight tensor:", weight.flatten()[:10])
         print("Shape of the bytes object:", len(input_int8.numpy().tobytes()))
 
 def write_all_tensors_to_hex(
-        input_int8, weight_int8, bias_bf16, inputScale_e8m0, weightScale_e8m0,
-        output_dir, input_start_addr=0, weight_start_addr=0, bias_start_addr=0,
-        inputScale_start_addr=0, weightScale_start_addr=0,
-        residual_start_addr="set by io_placement", has_residual=False, residual_bf16=None
+        output_dir,
+        input_int8=None, weight_int8=None, bias_bf16=None, inputScale_e8m0=None, weightScale_e8m0=None, residual_bf16=None,
+        input_start_addr=0, weight_start_addr=0, bias_start_addr=0, inputScale_start_addr=0, weightScale_start_addr=0,
+        residual_start_addr="set by io_placement",
     ):
-        write_list_to_hex(input_int8.numpy().tobytes(), output_dir + 'input_hex.txt', input_start_addr)
-        write_list_to_hex(weight_int8.numpy().tobytes(), output_dir + 'weight_hex.txt', weight_start_addr)
-        write_list_to_hex(bias_bf16, output_dir + 'bias_hex.txt', bias_start_addr)
-        write_list_to_hex(inputScale_e8m0, output_dir + 'inputScale_hex.txt', inputScale_start_addr)
-        write_list_to_hex(weightScale_e8m0, output_dir + 'weightScale_hex.txt', weightScale_start_addr)
-        if has_residual and residual_bf16 is not None:
+
+        if input_int8 is not None:
+            write_list_to_hex(input_int8.numpy().tobytes(), output_dir + 'input_hex.txt', input_start_addr)
+        else:
+            with open(output_dir + 'input_hex.txt', 'w') as f:
+                f.write("TENSOR_EXISTS: 0\n")
+
+        if weight_int8 is not None:
+            write_list_to_hex(weight_int8.numpy().tobytes(), output_dir + 'weight_hex.txt', weight_start_addr)
+        else:
+            with open(output_dir + 'weight_hex.txt', 'w') as f:
+                f.write("TENSOR_EXISTS: 0\n")
+
+        if bias_bf16 is not None:
+            write_list_to_hex(bias_bf16, output_dir + 'bias_hex.txt', bias_start_addr)
+        else:
+            with open(output_dir + 'bias_hex.txt', 'w') as f:
+                f.write("TENSOR_EXISTS: 0\n")
+
+        if inputScale_e8m0 is not None:
+            write_list_to_hex(inputScale_e8m0, output_dir + 'inputScale_hex.txt', inputScale_start_addr)
+        else:
+            with open(output_dir + 'inputScale_hex.txt', 'w') as f:
+                f.write("TENSOR_EXISTS: 0\n")
+
+        if weightScale_e8m0 is not None:
+            write_list_to_hex(weightScale_e8m0, output_dir + 'weightScale_hex.txt', weightScale_start_addr)
+        else:
+            with open(output_dir + 'weightScale_hex.txt', 'w') as f:
+                f.write("TENSOR_EXISTS: 0\n")
+
+        if residual_bf16 is not None:
             write_list_to_hex(residual_bf16, output_dir + 'residual_hex.txt', residual_start_addr)
+        else:
+            with open(output_dir + 'residual_hex.txt', 'w') as f:
+                f.write("TENSOR_EXISTS: 0\n")
 
 
 # For writing partial sum output from a prior kernel to raw binary file
@@ -159,10 +178,134 @@ def parse_zircon_workarounds():
         print(f"\033[93mINFO: K dimension host tiling enabled. Using {num_k_host_tiling_kernels} kernels with index {k_dim_host_tiling_idx}.\033[0m")
 
 
-    return zircon_fx_fy_stride_workaround, zircon_cgra_psum_workaround, psum_idx, num_psums, \
-           zircon_input_act_padding_workaround, zircon_input_act_padding_workaround_size, \
-           k_dim_host_tiling, num_k_host_tiling_kernels, k_dim_host_tiling_idx
+    return {
+        "zircon_fx_fy_stride_workaround": zircon_fx_fy_stride_workaround,
+        "zircon_cgra_psum_workaround": zircon_cgra_psum_workaround,
+        "psum_idx": psum_idx,
+        "num_psums": num_psums,
+        "zircon_input_act_padding_workaround": zircon_input_act_padding_workaround,
+        "zircon_input_act_padding_workaround_size": zircon_input_act_padding_workaround_size,
+        "k_dim_host_tiling": k_dim_host_tiling,
+        "num_k_host_tiling_kernels": num_k_host_tiling_kernels,
+        "k_dim_host_tiling_idx": k_dim_host_tiling_idx
+    }
 
+
+def parse_input(base_path, input_tensor_data, zircon_workarounds):
+    # Shape is in format: (OC, IC, Y, X)
+    input = read_tensor(base_path + input_tensor_data["node"] + ".bin", tuple(input_tensor_data["shape"]))
+    if zircon_workarounds["zircon_input_act_padding_workaround"]:
+        input = F.pad(input, pad=(0, zircon_workarounds["zircon_input_act_padding_workaround_size"], 0, zircon_workarounds["zircon_input_act_padding_workaround_size"])) # Pad X and Y dimensions with zeros
+    # Re-order it so IC is the innermost dimension (Y, X, OC, IC)
+    input_reordered = input.permute(2, 3, 0, 1)
+    if zircon_workarounds["zircon_cgra_psum_workaround"]:
+        input_reordered = input_reordered.reshape((input.shape[2], input.shape[3], input.shape[0], input.shape[1] // ZIRCON_MU_IC0, ZIRCON_MU_IC0))
+        input_reordered = input_reordered.permute(3, 0, 1, 2, 4)
+    input_int8 = input_reordered.to(torch.int8)
+
+    return input_int8
+
+
+def parse_inputScale(base_path, inputScale_tensor_data, zircon_workarounds):
+    # Shape is in format: (OC, IC / BLOCK_SIZE, Y, X)
+    inputScale = read_tensor(base_path + inputScale_tensor_data["node"] + ".bin", tuple(inputScale_tensor_data["shape"]))
+    if zircon_workarounds["zircon_input_act_padding_workaround"]:
+        inputScale = F.pad(inputScale, pad=(0, zircon_workarounds["zircon_input_act_padding_workaround_size"], 0, zircon_workarounds["zircon_input_act_padding_workaround_size"])) # Pad X and Y dimensions with zeros
+    # Re-order it so IC is the innermost dimension (Y, X, OC, IC / BLOCK_SIZE)
+    inputScale_reordered = inputScale.permute(2, 3, 0, 1)
+    if zircon_workarounds["zircon_cgra_psum_workaround"]:
+        inputScale_reordered = inputScale_reordered.permute(3, 0, 1, 2)
+    inputScale_e8m0 = float_to_e8m0(inputScale_reordered)
+
+    return inputScale_e8m0
+
+def parse_weight(base_path, weight_tensor_data, zircon_workarounds):
+     # Shape is in format: (OC, IC, FY, FX)
+    weight = read_tensor(base_path + weight_tensor_data["node"] + ".bin", tuple(weight_tensor_data["shape"]))
+    if zircon_workarounds["zircon_fx_fy_stride_workaround"]:
+        weight = F.pad(weight, pad=(0, 2, 0, 2))
+    # Re-order it so OC is the innermost dimension (FY, FX, IC, OC)
+    weight_reordered = weight.permute(2, 3, 1, 0)
+    if zircon_workarounds["zircon_cgra_psum_workaround"]:
+        weight_reordered = weight_reordered.reshape((weight.shape[2], weight.shape[3], weight.shape[1] // ZIRCON_MU_IC0, ZIRCON_MU_IC0, weight.shape[0]))
+        weight_reordered = weight_reordered.permute(2, 0, 1, 3, 4)
+    if zircon_workarounds["k_dim_host_tiling"]:
+        num_k_host_tiling_kernels = zircon_workarounds["num_k_host_tiling_kernels"]
+        k_dim_host_tiling_idx = zircon_workarounds["k_dim_host_tiling_idx"]
+        weight_reordered = weight_reordered.reshape((weight.shape[2], weight.shape[3], weight.shape[1], num_k_host_tiling_kernels, weight.shape[0] // num_k_host_tiling_kernels))
+        weight_reordered = weight_reordered.permute(3, 0, 1, 2, 4)
+        weight_reordered = weight_reordered[k_dim_host_tiling_idx]
+    weight_int8 = weight_reordered.to(torch.int8)
+
+    return weight_int8
+
+def parse_weightScale(base_path, weightScale_tensor_data, zircon_workarounds):
+     # Shape is in format: (OC, IC / BLOCK_SIZE, FY, FX)
+    weightScale = read_tensor(base_path + weightScale_tensor_data["node"] + ".bin", tuple(weightScale_tensor_data["shape"]))
+    if zircon_workarounds["zircon_fx_fy_stride_workaround"]:
+        weightScale = F.pad(weightScale, pad=(0, 2, 0, 2))
+    # Re-order it so OC is the innermost dimension (FY, FX, IC / BLOCK_SIZE, OC)
+    weightScale_reordered = weightScale.permute(2, 3, 1, 0)
+    if zircon_workarounds["zircon_cgra_psum_workaround"]:
+        weightScale_reordered = weightScale_reordered.permute(2, 0, 1, 3)
+    if zircon_workarounds["k_dim_host_tiling"]:
+        num_k_host_tiling_kernels = zircon_workarounds["num_k_host_tiling_kernels"]
+        k_dim_host_tiling_idx = zircon_workarounds["k_dim_host_tiling_idx"]
+        weightScale_reordered = weightScale_reordered.reshape((weightScale.shape[2], weightScale.shape[3], weightScale.shape[1], num_k_host_tiling_kernels, weightScale.shape[0] // num_k_host_tiling_kernels))
+        weightScale_reordered = weightScale_reordered.permute(3, 0, 1, 2, 4)
+        weightScale_reordered = weightScale_reordered[k_dim_host_tiling_idx]
+    weightScale_e8m0 = float_to_e8m0(weightScale_reordered)
+
+    return weightScale_e8m0
+
+def parse_bias(base_path, bias_tensor_data, zircon_workarounds):
+    bias = read_tensor(base_path + bias_tensor_data["node"] + ".bin", tuple(bias_tensor_data["shape"]))
+    if zircon_workarounds["zircon_cgra_psum_workaround"] and zircon_workarounds["psum_idx"] != 0:
+        # If doing psum workaround, bias is zero for all but the 0th kernel
+        bias = torch.zeros((bias.shape[0],), dtype=torch.float32)
+    if zircon_workarounds["k_dim_host_tiling"]:
+        num_k_host_tiling_kernels = zircon_workarounds["num_k_host_tiling_kernels"]
+        k_dim_host_tiling_idx = zircon_workarounds["k_dim_host_tiling_idx"]
+        bias = bias.reshape((num_k_host_tiling_kernels, bias.shape[0] // num_k_host_tiling_kernels))
+        bias = bias[k_dim_host_tiling_idx]
+    bias_bf16 = float32_to_bfloat16_bits(bias)
+
+    return bias_bf16
+
+def parse_residual(base_path, residual_tensor_data, h2h_dir, zircon_workarounds):
+    # Shape is in format: (OC, IC, Y, X)
+    residual = read_tensor(base_path + residual_tensor_data["node"] + ".bin",
+                            (residual_tensor_data["shape"][0], residual_tensor_data["shape"][1], residual_tensor_data["shape"][2], residual_tensor_data["shape"][3]))
+
+    if zircon_workarounds["zircon_fx_fy_stride_workaround"]:
+        residual_tmp = torch.zeros(residual.size(0), residual.size(1), 2*residual.size(2), 2*residual.size(3), device=residual.device, dtype=residual.dtype)
+        # Place original values at odd indices (1, 3, 5, ...) using slicing
+        residual_tmp[:, :, 1::2, 1::2] = residual
+        residual = residual_tmp
+
+    if zircon_workarounds["zircon_input_act_padding_workaround"]:
+        residual = F.pad(residual, pad=(0, zircon_workarounds["zircon_input_act_padding_workaround_size"], 0, zircon_workarounds["zircon_input_act_padding_workaround_size"]), value=-1000) # Pad with -1000 instead of 0s to catch potential bugs
+
+    # Re-order it so IC is the innermost dimension (Y, X, OC, IC)
+    residual_reordered = residual.permute(2, 3, 0, 1)
+    if zircon_workarounds["k_dim_host_tiling"]:
+        num_k_host_tiling_kernels = zircon_workarounds["num_k_host_tiling_kernels"]
+        k_dim_host_tiling_idx = zircon_workarounds["k_dim_host_tiling_idx"]
+        residual_reordered = residual_reordered.reshape((residual.shape[2], residual.shape[3], residual.shape[0], num_k_host_tiling_kernels, residual.shape[1] // num_k_host_tiling_kernels))
+        residual_reordered = residual_reordered.permute(3, 0, 1, 2, 4)
+        residual_reordered = residual_reordered[k_dim_host_tiling_idx]
+    residual_bf16 = float32_to_bfloat16_bits(residual_reordered)
+    residual_bf16_be = residual_bf16.byteswap().newbyteorder('>')
+
+    if zircon_workarounds["zircon_cgra_psum_workaround"] and (zircon_workarounds["psum_idx"] == 0):
+        residual_bf16_be.tofile(f'{h2h_dir}/hw_partial_sum_input_stencil.raw')
+    # Write the residual_bf16_be to a raw file except for psum workaround middle kernels
+    elif not (zircon_workarounds["zircon_cgra_psum_workaround"] and zircon_workarounds["psum_idx"] != (zircon_workarounds["num_psums"] - 1)):
+        residual_bf16_be.tofile(f'{h2h_dir}/hw_residual_input_stencil.raw')
+    # Flatten residual_bf16 and convert to a python list
+    residual_bf16 = residual_bf16.flatten().tolist()
+
+    return residual_bf16
 
 def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
     # Base path for the binary files
@@ -171,14 +314,47 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
     with open("/aha/voyager/tensor_metadata.json", "r") as f:
         tensor_metadata = json.load(f)
 
+    has_input = tensor_metadata["has_input"]
+    has_weight = tensor_metadata["has_weight"]
+    has_input_scale = tensor_metadata["has_input_scale"]
+    has_weight_scale = tensor_metadata["has_weight_scale"]
+    has_bias = tensor_metadata["has_bias"]
     has_residual = tensor_metadata["has_residual"]
 
-    input_tensor_data = tensor_metadata["ops"][0]["kwargs"]["input"]["tensor"]
-    weight_tensor_data = tensor_metadata["ops"][0]["kwargs"]["weight"]["tensor"]
-    bias_tensor_data = tensor_metadata["ops"][0]["kwargs"]["bias"]["tensor"]
-    inputScale_tensor_data = tensor_metadata["ops"][0]["kwargs"]["input_scale"]["tensor"]
-    weightScale_tensor_data = tensor_metadata["ops"][0]["kwargs"]["weight_scale"]["tensor"]
+    zircon_workarounds = parse_zircon_workarounds()
 
+    # INPUT
+    if has_input:
+        input_tensor_data = tensor_metadata["ops"][0]["kwargs"]["input"]["tensor"]
+        input_start_addr = input_tensor_data["glb_base_address"]
+        input_int8 = parse_input(base_path, input_tensor_data, zircon_workarounds)
+
+    # INPUT SCALE
+    if has_input_scale:
+        inputScale_tensor_data = tensor_metadata["ops"][0]["kwargs"]["input_scale"]["tensor"]
+        inputScale_start_addr = inputScale_tensor_data["glb_base_address"]
+        inputScale_e8m0 = parse_inputScale(base_path, inputScale_tensor_data, zircon_workarounds)
+
+    # WEIGHT
+    if has_weight:
+        weight_tensor_data = tensor_metadata["ops"][0]["kwargs"]["weight"]["tensor"]
+        weight_start_addr = weight_tensor_data["glb_base_address"]
+        weight_int8 = parse_weight(base_path, weight_tensor_data, zircon_workarounds)
+
+    # WEIGHT SCALE
+    if has_weight_scale:
+        weightScale_tensor_data = tensor_metadata["ops"][0]["kwargs"]["weight_scale"]["tensor"]
+        weightScale_start_addr = weightScale_tensor_data["glb_base_address"]
+        weightScale_e8m0 = parse_weightScale(
+            base_path, weightScale_tensor_data, zircon_workarounds)
+
+    # BIAS
+    if has_bias:
+        bias_tensor_data = tensor_metadata["ops"][0]["kwargs"]["bias"]["tensor"]
+        bias_start_addr = bias_tensor_data["glb_base_address"]
+        bias_bf16 = parse_bias(base_path, bias_tensor_data, zircon_workarounds)
+
+    # RESIDUAL
     if has_residual:
         all_op_names = []
         for op in tensor_metadata["ops"]:
@@ -193,152 +369,40 @@ def parse_tensors(model, layer, datatype, h2h_dir, debug_mode):
                         if op["kwargs"][key]["tensor"]["node"] not in all_op_names:
                             residual_tensor_data = op["kwargs"][key]["tensor"]
                             break
-
-    mu_glb_base_addr = tensor_metadata["mu_glb_base_address"]
-
-
-    zircon_fx_fy_stride_workaround, zircon_cgra_psum_workaround, psum_idx, num_psums, \
-    zircon_input_act_padding_workaround, zircon_input_act_padding_workaround_size, \
-    k_dim_host_tiling, num_k_host_tiling_kernels, k_dim_host_tiling_idx = parse_zircon_workarounds()
-
-    # INPUT
-    # Shape is in format: (OC, IC, Y, X)
-    input = read_tensor(base_path + input_tensor_data["node"] + ".bin",
-                        (input_tensor_data["shape"][0], input_tensor_data["shape"][1], input_tensor_data["shape"][2], input_tensor_data["shape"][3]))
-    if zircon_input_act_padding_workaround:
-        input = F.pad(input, pad=(0, zircon_input_act_padding_workaround_size, 0, zircon_input_act_padding_workaround_size)) # Pad X and Y dimensions with zeros
-    # Re-order it so IC is the innermost dimension (Y, X, OC, IC)
-    input_reordered = input.permute(2, 3, 0, 1)
-    if zircon_cgra_psum_workaround:
-        input_reordered = input_reordered.reshape((input_tensor_data["shape"][2], input_tensor_data["shape"][3], input_tensor_data["shape"][0], input_tensor_data["shape"][1] // 64, 64))
-        input_reordered = input_reordered.permute(3, 0, 1, 2, 4)
-    input_int8 = input_reordered.to(torch.int8)
-    input_start_addr = input_tensor_data["glb_base_address"]
-
-    # INPUT SCALE
-    # Shape is in format: (OC, IC / BLOCK_SIZE, Y, X)
-    inputScale = read_tensor(base_path + inputScale_tensor_data["node"] + ".bin",
-                             (inputScale_tensor_data["shape"][0], inputScale_tensor_data["shape"][1], inputScale_tensor_data["shape"][2], inputScale_tensor_data["shape"][3]))
-    if zircon_input_act_padding_workaround:
-        inputScale = F.pad(inputScale, pad=(0, zircon_input_act_padding_workaround_size, 0, zircon_input_act_padding_workaround_size)) # Pad X and Y dimensions with zeros
-    # Re-order it so IC is the innermost dimension (Y, X, OC, IC / BLOCK_SIZE)
-    inputScale_reordered = inputScale.permute(2, 3, 0, 1)
-    if zircon_cgra_psum_workaround:
-        inputScale_reordered = inputScale_reordered.permute(3, 0, 1, 2)
-    inputScale_e8m0 = float_to_e8m0(inputScale_reordered)
-    inputScale_start_addr = inputScale_tensor_data["glb_base_address"]
-
-    # WEIGHT
-    # Shape is in format: (OC, IC, FY, FX)
-    weight = read_tensor(base_path + weight_tensor_data["node"] + ".bin",
-                         (weight_tensor_data["shape"][0], weight_tensor_data["shape"][1], weight_tensor_data["shape"][2], weight_tensor_data["shape"][3]))
-    if zircon_fx_fy_stride_workaround:
-        weight = F.pad(weight, pad=(0, 2, 0, 2))
-    # Re-order it so OC is the innermost dimension (FY, FX, IC, OC)
-    weight_reordered = weight.permute(2, 3, 1, 0)
-    if zircon_cgra_psum_workaround:
-        weight_reordered = weight_reordered.reshape((weight_tensor_data["shape"][2], weight_tensor_data["shape"][3], weight_tensor_data["shape"][1] // 64, 64, weight_tensor_data["shape"][0]))
-        weight_reordered = weight_reordered.permute(2, 0, 1, 3, 4)
-    if k_dim_host_tiling:
-        weight_reordered = weight_reordered.reshape((weight_tensor_data["shape"][2], weight_tensor_data["shape"][3], weight_tensor_data["shape"][1], num_k_host_tiling_kernels, weight_tensor_data["shape"][0] // num_k_host_tiling_kernels))
-        weight_reordered = weight_reordered.permute(3, 0, 1, 2, 4)
-        weight_reordered = weight_reordered[k_dim_host_tiling_idx]
-    weight_int8 = weight_reordered.to(torch.int8)
-    weight_start_addr = weight_tensor_data["glb_base_address"]
-
-    # WEIGHT SCALE
-    # Shape is in format: (OC, IC / BLOCK_SIZE, FY, FX)
-    weightScale = read_tensor(base_path + weightScale_tensor_data["node"] + ".bin",
-                              (weightScale_tensor_data["shape"][0], weightScale_tensor_data["shape"][1], weightScale_tensor_data["shape"][2], weightScale_tensor_data["shape"][3]))
-    if zircon_fx_fy_stride_workaround:
-        weightScale = F.pad(weightScale, pad=(0, 2, 0, 2))
-    # Re-order it so OC is the innermost dimension (FY, FX, IC / BLOCK_SIZE, OC)
-    weightScale_reordered = weightScale.permute(2, 3, 1, 0)
-    if zircon_cgra_psum_workaround:
-        weightScale_reordered = weightScale_reordered.permute(2, 0, 1, 3)
-    if k_dim_host_tiling:
-        weightScale_reordered = weightScale_reordered.reshape((weightScale_tensor_data["shape"][2], weightScale_tensor_data["shape"][3], weightScale_tensor_data["shape"][1], num_k_host_tiling_kernels, weightScale_tensor_data["shape"][0] // num_k_host_tiling_kernels))
-        weightScale_reordered = weightScale_reordered.permute(3, 0, 1, 2, 4)
-        weightScale_reordered = weightScale_reordered[k_dim_host_tiling_idx]
-    weightScale_e8m0 = float_to_e8m0(weightScale_reordered)
-    weightScale_start_addr = weightScale_tensor_data["glb_base_address"]
-
-    # BIAS
-    bias = read_tensor(base_path + bias_tensor_data["node"] + ".bin", (bias_tensor_data["shape"][0]))
-    if zircon_cgra_psum_workaround and psum_idx != 0:
-        # If doing psum workaround, bias is zero for all but the 0th kernel
-        bias = torch.zeros((bias_tensor_data["shape"][0],), dtype=torch.float32)
-    if k_dim_host_tiling:
-        bias = bias.reshape((num_k_host_tiling_kernels, bias_tensor_data["shape"][0] // num_k_host_tiling_kernels))
-        bias = bias[k_dim_host_tiling_idx]
-    bias_bf16 = float32_to_bfloat16_bits(bias)
-    bias_start_addr = bias_tensor_data["glb_base_address"]
-
-
-    # RESIDUAL
-    # Shape is in format: (OC, IC, Y, X)
-    if has_residual:
-        residual = read_tensor(base_path + residual_tensor_data["node"] + ".bin",
-                               (residual_tensor_data["shape"][0], residual_tensor_data["shape"][1], residual_tensor_data["shape"][2], residual_tensor_data["shape"][3]))
-
-        if zircon_fx_fy_stride_workaround:
-            residual_tmp = torch.zeros(residual.size(0), residual.size(1), 2*residual.size(2), 2*residual.size(3), device=residual.device, dtype=residual.dtype)
-            # Place original values at odd indices (1, 3, 5, ...) using slicing
-            residual_tmp[:, :, 1::2, 1::2] = residual
-            residual = residual_tmp
-
-        if zircon_input_act_padding_workaround:
-            residual = F.pad(residual, pad=(0, zircon_input_act_padding_workaround_size, 0, zircon_input_act_padding_workaround_size), value=-1000) # Pad with -1000 instead of 0s to catch potential bugs
-
-        # Re-order it so IC is the innermost dimension (Y, X, OC, IC)
-        residual_reordered = residual.permute(2, 3, 0, 1)
-        if k_dim_host_tiling:
-            residual_reordered = residual_reordered.reshape((residual.shape[2], residual.shape[3], residual.shape[0], num_k_host_tiling_kernels, residual.shape[1] // num_k_host_tiling_kernels))
-            residual_reordered = residual_reordered.permute(3, 0, 1, 2, 4)
-            residual_reordered = residual_reordered[k_dim_host_tiling_idx]
-        residual_bf16 = float32_to_bfloat16_bits(residual_reordered)
-        residual_bf16_be = residual_bf16.byteswap().newbyteorder('>')
-
-        if zircon_cgra_psum_workaround and (psum_idx == 0):
-            residual_bf16_be.tofile(f'{h2h_dir}/hw_partial_sum_input_stencil.raw')
-        # Write the residual_bf16_be to a raw file except for psum workaround middle kernels
-        elif not(zircon_cgra_psum_workaround and psum_idx != (num_psums - 1)):
-            residual_bf16_be.tofile(f'{h2h_dir}/hw_residual_input_stencil.raw')
-        # Flatten residual_bf16 and convert to a python list
-        residual_bf16 = residual_bf16.flatten().tolist()
+        residual_bf16 = parse_residual(base_path, residual_tensor_data, h2h_dir, zircon_workarounds)
 
     torch.set_printoptions(precision=10)
 
     # For psum_workoround, if not kernel 0, read prior kernel output from text file and convert to raw binary file
-    if zircon_cgra_psum_workaround and (psum_idx != 0):
-        hw_output_txt_path = f'/aha/Halide-to-Hardware/apps/hardware_benchmarks/apps/zircon_psum_reduction_fp/{model}-{layer}_gold/kernel_{psum_idx - 1}_output.txt'
+    if zircon_workarounds["zircon_cgra_psum_workaround"] and (zircon_workarounds["psum_idx"] != 0):
+        hw_output_txt_path = f'/aha/Halide-to-Hardware/apps/hardware_benchmarks/apps/zircon_psum_reduction_fp/{model}-{layer}_gold/kernel_{zircon_workarounds["psum_idx"] - 1}_output.txt'
         assert os.path.exists(hw_output_txt_path), f"The prior kernel output file {hw_output_txt_path} does not exist."
         # For the last psum, write to hw_residual_input_stencil.raw, otherwise write to hw_partial_sum_input_stencil.raw
-        if psum_idx == (num_psums - 1):
+        if zircon_workarounds["psum_idx"] == (zircon_workarounds["num_psums"] - 1):
             hw_output_raw_path = f'{h2h_dir}/hw_residual_input_stencil.raw'
         else:
             hw_output_raw_path = f'{h2h_dir}/hw_partial_sum_input_stencil.raw'
         hw_output_txt_to_raw(hw_output_txt_path, hw_output_raw_path)
 
     if debug_mode:
-        debug_print_tensors(
-            input, input_int8, bias, bias_bf16, inputScale, inputScale_e8m0,
-            weightScale, weightScale_e8m0, weight)
-
+        debug_print_tensors(input, input_int8, bias_bf16, inputScale_e8m0, weightScale_e8m0)
 
     output_dir = f'/aha/voyager/compiled_collateral/{model}-{layer}/tensor_files/'
 
     # Write the tensors to hex files in tensor_files directory
     write_all_tensors_to_hex(
-        input_int8, weight_int8, bias_bf16, inputScale_e8m0, weightScale_e8m0,
         output_dir,
-        input_start_addr=input_start_addr,
-        weight_start_addr=weight_start_addr,
-        bias_start_addr=bias_start_addr,
-        inputScale_start_addr=inputScale_start_addr,
-        weightScale_start_addr=weightScale_start_addr,
-        has_residual=has_residual,
-        residual_bf16=residual_bf16 if has_residual else None
+        input_int8=input_int8 if has_input else None,
+        weight_int8=weight_int8 if has_weight else None,
+        bias_bf16=bias_bf16 if has_bias else None,
+        inputScale_e8m0=inputScale_e8m0 if has_input_scale else None,
+        weightScale_e8m0=weightScale_e8m0 if has_weight_scale else None,
+        residual_bf16=residual_bf16 if has_residual else None,
+        input_start_addr=input_start_addr if has_input else 0,
+        weight_start_addr=weight_start_addr if has_weight else 0,
+        bias_start_addr=bias_start_addr if has_bias else 0,
+        inputScale_start_addr=inputScale_start_addr if has_input_scale else 0,
+        weightScale_start_addr=weightScale_start_addr if has_weight_scale else 0,
     )
 
 

--- a/scripts/aha_flow/parse_dnnLayer_tensors.py
+++ b/scripts/aha_flow/parse_dnnLayer_tensors.py
@@ -157,7 +157,7 @@ def parse_zircon_workarounds():
     if zircon_input_act_padding_workaround:
         assert "ZIRCON_INPUT_ACT_PADDING_WORKAROUND_SIZE" in os.environ, "ZIRCON_INPUT_ACT_PADDING_WORKAROUND_SIZE environment variable must be set for ZIRCON_INPUT_ACT_PADDING_WORKAROUND"
         zircon_input_act_padding_workaround_size = int(os.environ.get("ZIRCON_INPUT_ACT_PADDING_WORKAROUND_SIZE"))
-        zircon_input_act_padding_workaround_stride = int(os.environ.get("ZIRCON_INPUT_ACT_PADDING_WORKAROUND_STRIDE", 1))
+    zircon_input_act_padding_workaround_stride = int(os.environ.get("ZIRCON_INPUT_ACT_PADDING_WORKAROUND_STRIDE", 1))
 
     # K dimension host tiling: used in resnet18 conv5 in Zircon
     k_dim_host_tiling = "K_DIM_HOST_TILING" in os.environ and os.environ["K_DIM_HOST_TILING"] == "1"

--- a/test/common/AccuracyTester.cc
+++ b/test/common/AccuracyTester.cc
@@ -27,8 +27,8 @@ bool run_sample(std::string model_name, std::string data_dir,
 
   const auto model = network.model;
 
-  bool is_cnn = model_name == "resnet18" || model_name == "resnet50";
-  auto data_loader = std::make_unique<DataLoader>(memory.get(), false, is_cnn);
+
+ auto data_loader = std::make_unique<DataLoader>(memory.get(), false);
 
   int num_classes;
   if (model_name == "mobilebert" || model_name == "bert") {
@@ -44,19 +44,15 @@ bool run_sample(std::string model_name, std::string data_dir,
   // Load inputs and parameters
   std::string inputs_dir = data_dir + "/" + sample;
   for (const auto& tensor : model.inputs()) {
-    data_loader->load_tensor(tensor, inputs_dir, is_cnn);
+    data_loader->load_tensor(tensor, inputs_dir, false);
   }
 
-  // Fully connected layer, or linear ops with input of a 1D tensor, is run
-  // on the vector unit. Its weight does not need to be transposed. We check
-  // if an op is a FC by checking its output dimension. This should be
-  // improved in the future.
+
   std::string params_dir = std::string(getenv("CODEGEN_DIR")) + "/networks/" +
                            model_name + "/" + std::getenv("DATATYPE") +
                            "/tensor_files";
   for (const auto& tensor : model.parameters()) {
-    bool transpose_weight = tensor.shape(0) != num_classes;
-    data_loader->load_tensor(tensor, params_dir, transpose_weight);
+    data_loader->load_tensor(tensor, params_dir, false);
   }
 
   // Run inference

--- a/test/common/DataLoader.cc
+++ b/test/common/DataLoader.cc
@@ -7,9 +7,9 @@
 #include "test/common/VerificationTypes.h"
 #include "xtensor/xadapt.hpp"
 
-DataLoader::DataLoader(MemoryInterface* memory_interface, bool is_dut,
-                       bool is_cnn)
-    : memory_interface(memory_interface), is_dut(is_dut), is_cnn(is_cnn) {}
+DataLoader::DataLoader(MemoryInterface* memory_interface, bool is_dut)
+    : memory_interface(memory_interface), is_dut(is_dut) {}
+
 
 void DataLoader::load_tensor(const codegen::Tensor& tensor,
                              std::string data_dir, bool transpose,
@@ -103,8 +103,8 @@ void DataLoader::load_inputs(const codegen::Operation param,
       if (value.has_tensor() && tensor.has_memory() &&
           tensor.node().find("constant") == std::string::npos) {
         bool is_conv2d = op.target().find("conv2d") != std::string::npos;
-        bool is_replication = is_conv2d && tensor.shape(1) == 3 && is_dut;
-        load_tensor(value.tensor(), data_dir, is_cnn, is_replication);
+        bool is_replication = is_conv2d && tensor.shape(tensor.shape().size() - 1) == 3 && is_dut;
+        load_tensor(value.tensor(), data_dir, false, is_replication);
       }
     }
   }
@@ -116,7 +116,6 @@ void DataLoader::load_outputs(const codegen::Operation param,
 
   const auto op_list = get_op_list(param);
   std::string opcode = op_list[0].target();
-  bool transpose = is_cnn && opcode != "linear" && opcode != "linear_mx";
 
   uint64_t address = 0;
 
@@ -127,7 +126,7 @@ void DataLoader::load_outputs(const codegen::Operation param,
     output_tensor.mutable_memory()->set_partition(-1);
     output_tensor.mutable_memory()->set_address(address);
 
-    load_tensor(output_tensor, data_dir, transpose);
+    load_tensor(output_tensor, data_dir, false);
     address += get_size(tensor);
   }
 }

--- a/test/common/DataLoader.h
+++ b/test/common/DataLoader.h
@@ -13,7 +13,7 @@
 
 class DataLoader {
  public:
-  DataLoader(MemoryInterface*, bool, bool);
+  DataLoader(MemoryInterface*, bool);
 
   void load_inputs(const codegen::Operation param, std::string data_dir,
                    bool random_data = false);
@@ -27,5 +27,4 @@ class DataLoader {
   MemoryInterface* memory_interface;
   // special addressing is sometimes needed for DUT memory (ex. replication)
   bool is_dut;
-  bool is_cnn;
 };

--- a/test/common/Harness.cc
+++ b/test/common/Harness.cc
@@ -473,12 +473,14 @@ void Harness::sendParams() {
     const char* zircon_cgra_psum_workaround_env = std::getenv("ZIRCON_CGRA_PSUM_WORKAROUND");
     const char* k_dim_host_tiling_env = std::getenv("K_DIM_HOST_TILING");
     const char* zircon_input_act_padding_workaround_env = std::getenv("ZIRCON_INPUT_ACT_PADDING_WORKAROUND");
+    const char* zircon_inner_loop_reduction_workaround_env = std::getenv("ZIRCON_INNER_LOOP_REDUCTION_WORKAROUND");
     bool dump_tiling = true;
     bool zircon_fx_fy_stride_workaround = zircon_fx_fy_stride_workaround_env && std::stoi(zircon_fx_fy_stride_workaround_env) == 1;
     bool zircon_cgra_psum_workaround = zircon_cgra_psum_workaround_env && std::stoi(zircon_cgra_psum_workaround_env) == 1;
     bool k_dim_host_tiling = k_dim_host_tiling_env && std::stoi(k_dim_host_tiling_env) == 1;
     bool zircon_input_act_padding_workaround = zircon_input_act_padding_workaround_env && std::stoi(zircon_input_act_padding_workaround_env) == 1;
-    bool hack_tiling = zircon_fx_fy_stride_workaround || zircon_cgra_psum_workaround || k_dim_host_tiling || zircon_input_act_padding_workaround;
+    bool zircon_inner_loop_reduction_workaround = zircon_inner_loop_reduction_workaround_env && std::stoi(zircon_inner_loop_reduction_workaround_env) == 1;
+    bool hack_tiling = zircon_fx_fy_stride_workaround || zircon_cgra_psum_workaround || k_dim_host_tiling || zircon_input_act_padding_workaround || zircon_inner_loop_reduction_workaround;
     // Last two args are dump tiling and hack tiling for the AHA flow
     MapOperation(currentOperation, dump_accelerator_params, dump_accelerator_memory_maps, dump_tiling, hack_tiling);
 

--- a/test/common/Harness.cc
+++ b/test/common/Harness.cc
@@ -536,21 +536,52 @@ void Harness::sendParams() {
 
         uint64_t glb_base_addr = tensor_metadata["mu_glb_base_address"].get<uint64_t>();
         printf("\nMU-GLB base address: %d\n", glb_base_addr);
-        uint64_t input_offset = tensor_metadata["ops"][0]["kwargs"]["input"]["tensor"]["glb_base_address"];
-        uint64_t input_scale_offset = tensor_metadata["ops"][0]["kwargs"]["input_scale"]["tensor"]["glb_base_address"];
-        uint64_t weight_offset = tensor_metadata["ops"][0]["kwargs"]["weight"]["tensor"]["glb_base_address"];
-        uint64_t weight_scale_offset = tensor_metadata["ops"][0]["kwargs"]["weight_scale"]["tensor"]["glb_base_address"];
-        uint64_t bias_offset = tensor_metadata["ops"][0]["kwargs"]["bias"]["tensor"]["glb_base_address"];
+        uint64_t input_offset;
+        uint64_t input_scale_offset;
+        uint64_t weight_offset;
+        uint64_t weight_scale_offset;
+        uint64_t bias_offset;
 
-        auto& input_shape = tensor_metadata["ops"][0]["kwargs"]["input"]["tensor"]["shape"];
-        auto& weight_shape = tensor_metadata["ops"][0]["kwargs"]["weight"]["tensor"]["shape"];
-        auto& input_scale_shape = tensor_metadata["ops"][0]["kwargs"]["input_scale"]["tensor"]["shape"];
-        auto& weight_scale_shape = tensor_metadata["ops"][0]["kwargs"]["weight_scale"]["tensor"]["shape"];
+        int input_size = 1;
+        int input_scale_size = 1;
+        int weight_size = 1;
+        int weight_scale_size = 1;
 
-        int input_size = input_shape[0].get<int>() * input_shape[1].get<int>() * input_shape[2].get<int>() * input_shape[3].get<int>();
-        int weight_size = weight_shape[0].get<int>() * weight_shape[1].get<int>() * weight_shape[2].get<int>() * weight_shape[3].get<int>();
-        int input_scale_size = input_scale_shape[0].get<int>() * input_scale_shape[1].get<int>() * input_scale_shape[2].get<int>() * input_scale_shape[3].get<int>();
-        int weight_scale_size = weight_scale_shape[0].get<int>() * weight_scale_shape[1].get<int>() * weight_scale_shape[2].get<int>() * weight_scale_shape[3].get<int>();
+        if (tensor_metadata["has_input"].get<bool>()) {
+          input_offset = tensor_metadata["ops"][0]["kwargs"]["input"]["tensor"]["glb_base_address"];
+          auto& input_shape = tensor_metadata["ops"][0]["kwargs"]["input"]["tensor"]["shape"];
+          for (const auto& dim : input_shape) {
+            input_size *= dim.get<int>();
+          }
+        }
+
+        if (tensor_metadata["has_input_scale"].get<bool>()) {
+          input_scale_offset = tensor_metadata["ops"][0]["kwargs"]["input_scale"]["tensor"]["glb_base_address"];
+          auto& input_scale_shape = tensor_metadata["ops"][0]["kwargs"]["input_scale"]["tensor"]["shape"];
+          for (const auto& dim : input_scale_shape) {
+              input_scale_size *= dim.get<int>();
+          }
+        }
+
+        if (tensor_metadata["has_weight"].get<bool>()) {
+          weight_offset = tensor_metadata["ops"][0]["kwargs"]["weight"]["tensor"]["glb_base_address"];
+          auto& weight_shape = tensor_metadata["ops"][0]["kwargs"]["weight"]["tensor"]["shape"];
+          for (const auto& dim : weight_shape) {
+            weight_size *= dim.get<int>();
+          }
+        }
+
+        if (tensor_metadata["has_weight_scale"].get<bool>()) {
+          weight_scale_offset = tensor_metadata["ops"][0]["kwargs"]["weight_scale"]["tensor"]["glb_base_address"];
+          auto& weight_scale_shape = tensor_metadata["ops"][0]["kwargs"]["weight_scale"]["tensor"]["shape"];
+          for (const auto& dim : weight_scale_shape) {
+            weight_scale_size *= dim.get<int>();
+          }
+        }
+
+        if (tensor_metadata["has_bias"].get<bool>()) {
+          bias_offset = tensor_metadata["ops"][0]["kwargs"]["bias"]["tensor"]["glb_base_address"];
+        }
 
         // Adjust the offsets if using zircon CGRA PSUM workaround: account for tiling along reduction dimension
         if (zircon_cgra_psum_workaround) {
@@ -572,25 +603,37 @@ void Harness::sendParams() {
                 "environment variables to be set.");
           }
 
-          uint64_t input_offset_incr = psum_idx * (input_size / num_psums);
-          input_offset += input_offset_incr;
+          input_offset += psum_idx * (input_size / num_psums);;
           input_scale_offset += psum_idx * (input_scale_size/num_psums);
           weight_offset += psum_idx * (weight_size/num_psums);
           weight_scale_offset += psum_idx * (weight_scale_size/num_psums);
         }
 
-        // Print all the offsets
-        std::cout << "Input offset: " << input_offset << std::endl;
-        std::cout << "Input scale offset: " << input_scale_offset << std::endl;
-        std::cout << "Weight offset: " << weight_offset << std::endl;
-        std::cout << "Weight scale offset: " << weight_scale_offset << std::endl;
-        std::cout << "Bias offset: " << bias_offset << std::endl;
+        // Print all the offsets and add them to the dumpMatrixParams
+        if (tensor_metadata["has_input"].get<bool>()) {
+          std::cout << "Input offset: " << input_offset << std::endl;
+          dumpMatrixParams->INPUT_OFFSET = input_offset;
+        }
 
-        dumpMatrixParams->INPUT_OFFSET = input_offset;
-        dumpMatrixParams->INPUT_SCALE_OFFSET = input_scale_offset;
-        dumpMatrixParams->WEIGHT_OFFSET = weight_offset;
-        dumpMatrixParams->WEIGHT_SCALE_OFFSET = weight_scale_offset;
-        dumpMatrixParams->BIAS_OFFSET = bias_offset;
+        if (tensor_metadata["has_input_scale"].get<bool>()) {
+          std::cout << "Input scale offset: " << input_scale_offset << std::endl;
+          dumpMatrixParams->INPUT_SCALE_OFFSET = input_scale_offset;
+        }
+
+        if (tensor_metadata["has_weight"].get<bool>()) {
+          std::cout << "Weight offset: " << weight_offset << std::endl;
+          dumpMatrixParams->WEIGHT_OFFSET = weight_offset;
+        }
+
+        if (tensor_metadata["has_weight_scale"].get<bool>()) {
+          std::cout << "Weight scale offset: " << weight_scale_offset << std::endl;
+          dumpMatrixParams->WEIGHT_SCALE_OFFSET = weight_scale_offset;
+        }
+
+        if (tensor_metadata["has_bias"].get<bool>()) {
+          std::cout << "Bias offset: " << bias_offset << std::endl;
+          dumpMatrixParams->BIAS_OFFSET = bias_offset;
+        }
 
         dumpSerializedParams<MatrixParams, 32>(*dumpMatrixParams);
         matrixUnitStartSignal.SyncPop();

--- a/test/common/Simulation.cc
+++ b/test/common/Simulation.cc
@@ -86,12 +86,12 @@ void Simulation::load_data() {
 
   if (std::find(sims.begin(), sims.end(), "gold") != sims.end()) {
     memories["gold"] = new ArrayMemory(memory_sizes);
-    dataLoaders["gold"] = new DataLoader(memories["gold"], false, is_cnn);
+    dataLoaders["gold"] = new DataLoader(memories["gold"], false);
   }
   if (std::find(sims.begin(), sims.end(), "accelerator") != sims.end()) {
     memories["accelerator"] = new ArrayMemory(memory_sizes);
     dataLoaders["accelerator"] =
-        new DataLoader(memories["accelerator"], true, is_cnn);
+        new DataLoader(memories["accelerator"], true);
   }
 
   std::string project_root = std::string(getenv("PROJECT_ROOT"));
@@ -120,10 +120,7 @@ void Simulation::load_data() {
     }
 
     for (const auto& tensor : network->model.parameters()) {
-      bool has_transpose =
-          tensor.shape(0) != num_classes &&
-          tensor.node().find("_param_constant") != std::string::npos;
-      dataloader->load_tensor(tensor, data_dir, has_transpose);
+      dataloader->load_tensor(tensor, data_dir);
     }
 
     // Load the layer's input and output last
@@ -152,7 +149,7 @@ void Simulation::print_ideal_runtime(const Operation operation) {
     const auto weight_shape = get_shape(weight);
     const auto output_shape = get_shape(output);
 
-    int K = is_matmul ? weight_shape[weight_shape.size() - 1] : weight_shape[0];
+    int K = weight_shape[weight_shape.size() - 1];
 
     // the total number of operations is X * Y * C * FX * FY * K.
     long num_macs = get_size(output) * get_size(weight) / K;

--- a/test/common/Tiling.cc
+++ b/test/common/Tiling.cc
@@ -52,6 +52,9 @@ Tiling get_tiling(const Operation& operation, bool hack_tiling) {
   const char* zircon_input_act_padding_workaround_env = std::getenv("ZIRCON_INPUT_ACT_PADDING_WORKAROUND");
   bool zircon_input_act_padding_workaround = zircon_input_act_padding_workaround_env && std::stoi(zircon_input_act_padding_workaround_env) == 1;
 
+  const char* zircon_inner_loop_reduction_workaround_env = std::getenv("ZIRCON_INNER_LOOP_REDUCTION_WORKAROUND");
+  bool zircon_inner_loop_reduction_workaround = zircon_inner_loop_reduction_workaround_env && std::stoi(zircon_inner_loop_reduction_workaround_env) == 1;
+
   Tiling tiling;
   if (manual_tiling || !operation.has_valid_tiling) {
     if (first_op.target() == "conv2d" || first_op.target() == "conv2d_mx") {
@@ -68,6 +71,14 @@ Tiling get_tiling(const Operation& operation, bool hack_tiling) {
       tiling.stride = stride[0];
     } else {
       tiling.stride = 1;
+    }
+
+    // Inner loop reduction workaround for Zircon.
+    // The workaround ensures there is a non-trivial reduction loop in the inner level. It moves the outer channel loop to inner level.
+    // This step is needed to avoid a bug in the Zircon MU.
+    if (zircon_inner_loop_reduction_workaround && hack_tiling) {
+      tiling.loops[1][tiling.reduction_loop_index[1]] *= tiling.loops[0][tiling.reduction_loop_index[0]];
+      tiling.loops[0][tiling.reduction_loop_index[0]] = 1;
     }
 
     // PSUM workaround for Zircon. MU reduction loop bounds must be 1 for MU to work.

--- a/test/common/Tiling.cc
+++ b/test/common/Tiling.cc
@@ -145,8 +145,8 @@ Tiling get_zircon_fx_fy_stride_workaround_tiling(const codegen::OpOverload param
   int stride = strides[0];
 
   // conv4 downsample
-  if (input_shape[1] == 128 && input_shape[2] == 28 && input_shape[3] == 28 &&
-      weight_shape[0] == 256 && weight_shape[2] == 1 && weight_shape[3] == 1 && stride == 2) {
+  if (input_shape[3] == 128 && input_shape[1] == 28 && input_shape[2] == 28 &&
+      weight_shape[3] == 256 && weight_shape[0] == 1 && weight_shape[1] == 1 && stride == 2) {
 
     tiling = {
           .loops = {{1, 1, 8, 2, 1, 1}, {1, 1, 3, 3, 28, 28}},
@@ -161,8 +161,8 @@ Tiling get_zircon_fx_fy_stride_workaround_tiling(const codegen::OpOverload param
           .replication = false,
       };
   // conv5 downsample
-  } else if (input_shape[1] == 256 && input_shape[2] == 14 && input_shape[3] == 14 &&
-      weight_shape[0] == 512 && weight_shape[2] == 1 && weight_shape[3] == 1 && stride == 2) {
+  } else if (input_shape[3] == 256 && input_shape[1] == 14 && input_shape[2] == 14 &&
+      weight_shape[3] == 512 && weight_shape[0] == 1 && weight_shape[1] == 1 && stride == 2) {
 
         tiling = {
           .loops = {{1, 1, 16, 4, 1, 1}, {1, 1, 3, 3, 14, 14}},
@@ -342,33 +342,39 @@ Tiling get_conv2d_tiling(const codegen::OpOverload param) {
   const auto input_shape = get_shape(input);
   const auto weight_shape = get_shape(weight);
 
-  const int output_height = (input_shape[2] + 2 * padding[0] -
-                             dilation[0] * (weight_shape[2] - 1) - 1) /
+  const int output_height = (input_shape[1] + 2 * padding[0] -
+                             dilation[0] * (weight_shape[0] - 1) - 1) /
                                 strides[0] +
                             1;
-  const int output_width = (input_shape[3] + 2 * padding[1] -
-                            dilation[1] * (weight_shape[3] - 1) - 1) /
+  const int output_width = (input_shape[2] + 2 * padding[1] -
+                            dilation[1] * (weight_shape[1] - 1) - 1) /
                                strides[1] +
                            1;
 
-  std::vector<int> output_shape = {input_shape[0], weight_shape[0],
-                                   output_height, output_width};
+
+  std::vector<int> output_shape = {
+      output_height,
+      output_width,
+      input_shape[3],
+      weight_shape[3],
+  };
+
 
   const int oc_unroll = OC_DIMENSION;
   const int ic_unroll = IC_DIMENSION;
 
   int x1 = 1, y1 = 1, k1 = 1;
   int x0 = output_shape[2];
-  int y0 = output_shape[3];
-  int k0 = weight_shape[0] / oc_unroll;
-  int c0 = weight_shape[1] / ic_unroll;
-  int fx = weight_shape[2];
-  int fy = weight_shape[3];
+  int y0 = output_shape[1];
+  int k0 = weight_shape[3] / oc_unroll;
+  int c0 = weight_shape[2] / ic_unroll;
+  int fx = weight_shape[1];
+  int fy = weight_shape[0];
   int stride = strides[0];
 
   // conv1
-  if (input_shape[1] == 3 && input_shape[2] == 224 && input_shape[3] == 224 &&
-      weight_shape[0] == 64 && weight_shape[2] == 7 && weight_shape[3] == 7) {
+  if (input_shape[3] == 3 && input_shape[1] == 224 && input_shape[2] == 224 &&
+      weight_shape[3] == 64 && weight_shape[0] == 7 && weight_shape[1] == 7) {
     int fx;
     if (IC_DIMENSION == 4) {
       fx = 7;
@@ -586,11 +592,11 @@ Tiling get_pool2d_tiling(const codegen::OpOverload op) {
   const auto kwargs = op.kwargs();
   const auto input_shape = get_shape(kwargs.at("input").tensor());
 
-  int K = input_shape[1];
+  int Y = input_shape[1];
   int X = input_shape[2];
-  int Y = input_shape[3];
+  int K = input_shape[3];
 
-  int x0, y0, stride;
+  int x0, y0, stride, padding, x1, y1, k0, actual_padding;
 
   if (kwargs.contains("output_size")) {
     const auto output_size = kwargs.at("output_size").int_list().values();
@@ -600,19 +606,28 @@ Tiling get_pool2d_tiling(const codegen::OpOverload op) {
     stride = X / output_h;
     x0 = X - (output_h - 1) * stride;
     y0 = Y - (output_w - 1) * stride;
+
+    x1 = X / x0;
+    y1 = Y / y0;
+    k0 = K / OC_DIMENSION;
+    actual_padding = 0;
   } else {
     const auto kernel_size = kwargs.at("kernel_size").int_list().values();
     const auto strides = kwargs.at("stride").int_list().values();
 
-    x0 = kernel_size[0];
-    y0 = kernel_size[1];
+    y0 = kernel_size[0];
+    x0 = kernel_size[1];
     stride = strides[0];
+
+    // calculate ouptut dimension (ignoring padding, which will be handled in
+    // hw)
+    x1 = (X + 2 * padding - x0) / stride + 1;
+    y1 = (Y + 2 * padding - y0) / stride + 1;
+    // pytorch assumes padding on all direction, not all of the values are used
+    actual_padding = (x1 - 1) * stride + x0 - X;
+    k0 = K / OC_DIMENSION;
+
   }
-
-  int x1 = X / x0;
-  int y1 = Y / y0;
-  int k0 = K / OC_DIMENSION;
-
   return {
       .loops = {{x1, y1, 1, 1, 1, 1}, {1, k0, 1, 1, y0, x0}},
       .x_loop_index = {0, 5},

--- a/test/common/operations/MatrixOps.h
+++ b/test/common/operations/MatrixOps.h
@@ -64,6 +64,9 @@ inline Buffer *gemm(std::any input_ptr, std::any input_scale_ptr,
     }
   }
 
+  spdlog::debug("Performing GEMM: {}x{}x{} * {}x{}x{}x{} -> {}x{}x{}\n", Y, X,
+                C, FY, FX, C, K, Y, X, K);
+
   // assert that none of tiling.loops are 0
   for (int j = 0; j < 3; j++) {
     assert(tiling.loops[0][j] != 0);

--- a/test/common/operations/Pooling.h
+++ b/test/common/operations/Pooling.h
@@ -6,12 +6,21 @@ template <typename T>
 T *pooling(std::any input_ptr, const std::vector<int> &input_shape,
            const std::vector<int> &output_shape, int stride, int kernel_size,
            int padding, const bool is_max_pool) {
-  int input_height = input_shape[2];
-  int input_width = input_shape[3];
-  int input_depth = input_shape[1];
+  int input_height = input_shape[1];
+  int input_width = input_shape[2];
+  int input_depth = input_shape[3];
 
   int output_height = output_shape[0];
   int output_width = output_shape[1];
+
+  spdlog::debug("Performing {} pooling with kernel size {} and stride {}\n",
+                is_max_pool ? "max" : "average", kernel_size, stride);
+  spdlog::debug("Input shape: {}x{}x{}\n", input_height, input_width,
+                input_depth);
+  spdlog::debug("Output shape: {}x{}x{}\n", output_height, output_width,
+                input_depth);
+  spdlog::debug("Padding: {}\n", padding);
+
 
   T *inputs = std::any_cast<T *>(input_ptr);
 
@@ -65,7 +74,7 @@ T *adaptive_avg_pool2d(std::map<std::string, std::any> &kwargs,
   std::vector<int> output_shape{static_cast<int>(output_size[0]),
                                 static_cast<int>(output_size[1])};
 
-  int input_height = input_shape[2];
+  int input_height = input_shape[1];
   int output_height = output_shape[0];
 
   int stride = input_height / output_height;
@@ -91,8 +100,8 @@ T *max_pool2d(std::map<std::string, std::any> &kwargs,
   const auto kernel_size = op_kwargs.at("kernel_size").int_list().values()[0];
   const auto padding = op_kwargs.at("padding").int_list().values()[0];
 
-  int input_height = input_shape[2];
-  int input_width = input_shape[3];
+  int input_height = input_shape[1];
+  int input_width = input_shape[2];
 
   int output_height = (input_height + 2 * padding - kernel_size) / stride + 1;
   int output_width = (input_width + 2 * padding - kernel_size) / stride + 1;

--- a/test/compiler/run_tiler.py
+++ b/test/compiler/run_tiler.py
@@ -271,6 +271,7 @@ def main():
         ]:
             continue
 
+        is_matmul = matrix_op.target in ["matmul", "matmul_mx"]
         weight_key = "weight" if "matmul" not in matrix_op.target else "other"
         weight = matrix_op.kwargs[weight_key].tensor
         if weight.HasField("reshape"):
@@ -296,6 +297,12 @@ def main():
             # matrix multiplication
             output_channels = weights_shape[0]
             input_channels = weights_shape[1]
+            kernel_height = 1
+            kernel_width = 1
+        elif len(weights_shape) == 3:
+            # matrix multiplication
+            output_channels = weights_shape[1] if not is_matmul else weights_shape[-1]
+            input_channels = weights_shape[0] if not is_matmul else weights_shape[-2]
             kernel_height = 1
             kernel_width = 1
         else:

--- a/test/compiler/run_tiler.py
+++ b/test/compiler/run_tiler.py
@@ -269,6 +269,7 @@ def main():
             "linear_mx",
             "matmul_mx",
         ]:
+            print(f"Unsupported operation: {matrix_op.target}, skipping")
             continue
 
         is_matmul = matrix_op.target in ["matmul", "matmul_mx"]
@@ -289,14 +290,14 @@ def main():
 
         if len(weights_shape) == 4:
             # convolution
-            output_channels = weights_shape[0]
-            input_channels = weights_shape[1]
-            kernel_height = weights_shape[2]
-            kernel_width = weights_shape[3]
+            output_channels = weights_shape[3]
+            input_channels = weights_shape[2]
+            kernel_height = weights_shape[1]
+            kernel_width = weights_shape[0]
         elif len(weights_shape) == 2:
             # matrix multiplication
-            output_channels = weights_shape[0]
-            input_channels = weights_shape[1]
+            output_channels = weights_shape[1] if not is_matmul else weights_shape[0]
+            input_channels = weights_shape[0] if not is_matmul else weights_shape[1]
             kernel_height = 1
             kernel_width = 1
         elif len(weights_shape) == 3:
@@ -322,8 +323,8 @@ def main():
                     input_channels = output_channels
                     output_channels = output_shape[3]
             else:
-                height = output_shape[2]
-                width = output_shape[3]
+                height = output_shape[1]
+                width = output_shape[2]
         elif len(output_shape) == 3:
             assert output_shape[0] == 1
             width = output_shape[1]
@@ -353,6 +354,14 @@ def main():
 
             width = input_shape[1]
             height = 1
+
+        print(f"Input channels: {input_channels}")
+        print(f"Output channels: {output_channels}")
+        print(f"Input height: {height}")
+        print(f"Input width: {width}")
+        print(f"Kernel height: {kernel_height}")
+        print(f"Kernel width: {kernel_width}")
+        print(f"Stride: {stride}")
 
         layer = interstellar.Layer(
             nifm=input_channels,

--- a/test/toolchain/Pooling.h
+++ b/test/toolchain/Pooling.h
@@ -18,7 +18,7 @@ void MapPoolingOperation(const codegen::Operation &param,
   const auto input = pooling_op.kwargs().at("input").tensor();
 
   const auto output = param.output();
-  const int output_dim = output.shape(1);
+  const int output_dim = output.shape(3);
 
   // input
   const auto input_memory = input.memory();


### PR DESCRIPTION
Update compiler. Move transpose logic out of testbench environment and into compiler. Generalize MU flow to support cases where not all 5 tensors are present. Clean up parseDnnLayerTensors.py. Add backbone code for im2col-based GEMM. Re-work downsample layers to use inner-reduction based workaround.  

Corresponding AHA PR: (https://github.com/StanfordAHA/aha/pull/2076)